### PR TITLE
✨ feat: Add BurnerHandler to create and manage burner accounts

### DIFF
--- a/packages/create-burner/readme.md
+++ b/packages/create-burner/readme.md
@@ -44,6 +44,7 @@ Easily manage, create, and interact with burner accounts on Starknets using this
 -   [Usage](#usage)
     -   [With React](#with-react)
     -   [Vanilla JavaScript](#vanilla-javascript)
+    -   [using BurnerHandler](#burnerhandler)
 -   [API](#api)
 -   [Contribute](#contribute)
 -   [License](#license)
@@ -86,6 +87,41 @@ import { BurnerManager } from "@dojoengine/create-burner";
 const manager = new BurnerManager(options);
 manager.init();
 const activeAccount = manager.getActiveAccount();
+```
+
+### Using BurnerHandler
+
+For simpler control and avoiding using hooks, you can use BurnerHandler:
+
+```typescript
+import { BurnerHandler } from "@dojoengine/create-burner";
+
+const config = {
+    nodeUrl: "your-node-url",
+    masterAddress: "your-master-address",
+    masterPrivateKey: "your-master-private-key",
+    accountClassHash: "your-account-class-hash",
+};
+
+const burnerHandler = new BurnerHandler(config);
+
+// Initialize the burner handler
+await burnerHandler.initialize();
+
+// List all burner accounts
+const burners = burnerHandler.listBurner();
+
+// Select a specific burner account
+const selectedAccount = burnerHandler.selectBurner("address-of-burner");
+
+// Get a specific burner account
+const burnerAccount = burnerHandler.getBurner("address-of-burner");
+
+// Create a new burner account
+const newBurnerAccount = await burnerHandler.createBurnerAccount();
+
+// Clear all burner accounts
+burnerHandler.clearBurner();
 ```
 
 ## API

--- a/packages/create-burner/src/manager/burnerHandler.ts
+++ b/packages/create-burner/src/manager/burnerHandler.ts
@@ -1,0 +1,63 @@
+
+import { Account, RpcProvider } from "starknet";
+import { BurnerManager } from "./burnerManager";
+
+interface BurnerConfig {
+    nodeUrl: string;
+    masterAddress: string;
+    masterPrivateKey: string;
+    accountClassHash: string;
+}
+
+export class BurnerHandler {
+    private burnerManager: BurnerManager;
+
+    constructor(config: BurnerConfig) {
+        const rpcProvider = new RpcProvider({ nodeUrl: config.nodeUrl });
+
+        const masterAccount = new Account(
+            rpcProvider,
+            config.masterAddress,
+            config.masterPrivateKey
+        );
+
+        this.burnerManager = new BurnerManager({
+            masterAccount,
+            accountClassHash: config.accountClassHash,
+            rpcProvider,
+        });
+    }
+
+    async initialize() {
+        try {
+            await this.burnerManager.create();
+            this.burnerManager.init();
+        } catch (e) {
+            console.error("Error initializing Burner Manager:", e);
+            throw e;
+        }
+    }
+
+    listBurner() {
+        return this.burnerManager.list();
+    };
+    
+    selectBurner = (address : string) => {
+        this.burnerManager.select(address);
+        return this.burnerManager.getActiveAccount();
+    };
+    
+    getBurner = (address: string) => {
+        return this.burnerManager.get(address);
+    };
+    
+    createBurnerAccount = async (burnerManager: string) => {
+        const newAccount = await this.burnerManager.create();
+        return newAccount;
+    };
+    
+    clearBurner() {
+        this.burnerManager.clear();
+    };
+    
+};

--- a/packages/create-burner/src/manager/burnerHandler.ts
+++ b/packages/create-burner/src/manager/burnerHandler.ts
@@ -1,4 +1,3 @@
-
 import { Account, RpcProvider } from "starknet";
 import { BurnerManager } from "./burnerManager";
 
@@ -40,23 +39,29 @@ export class BurnerHandler {
 
     listBurner() {
         return this.burnerManager.list();
-    };
-    
-    selectBurner = (address : string) => {
+    }
+
+    selectBurner = (address: string) => {
+        if (!address) {
+            return this.burnerManager.getActiveAccount();
+        }
         this.burnerManager.select(address);
         return this.burnerManager.getActiveAccount();
     };
-    
+
     getBurner = (address: string) => {
         return this.burnerManager.get(address);
     };
-    
-    createBurnerAccount = async (burnerManager: string) => {
-        return await this.burnerManager.create();;
+
+    createBurnerAccount = async () => {
+        return await this.burnerManager.create();
     };
-    
+
     clearBurner() {
         this.burnerManager.clear();
+    }
+
+    getActiveAccount = () => {
+        return this.burnerManager.getActiveAccount();
     };
-    
-};
+}

--- a/packages/create-burner/src/manager/index.ts
+++ b/packages/create-burner/src/manager/index.ts
@@ -1,2 +1,3 @@
 export { BurnerManager } from "./burnerManager";
 export { prefundAccount } from "./prefundAccount";
+export { BurnerHandler } from "./burnerHandler";


### PR DESCRIPTION
This commit adds the `BurnerHandler` class to the `create-burner` package. The `BurnerHandler` is responsible for creating and managing burner accounts. It includes methods for initializing, listing, selecting, getting, creating, and clearing burner accounts.

The `BurnerHandler` constructor takes a configuration object that includes the necessary parameters such as the node URL, master address, master private key, and account class hash.

The `initialize` method initializes the burner manager by creating the burner accounts and performing initialization tasks. If an error occurs during initialization, it is logged and thrown.

The `listBurner` method returns a list of all burner accounts managed by the `BurnerManager`.

The `selectBurner` method selects a burner account based on the given address and returns the active account.

The `getBurner` method retrieves a burner account based on the given address.

The `createBurnerAccount` method creates a new burner account using the `burnerManager` and returns the created account.

The `clearBurner` method clears all burner accounts managed by the `BurnerManager`.

Additionally, this commit exports the `BurnerHandler` class from the `manager/index.ts` file, allowing it to be used outside the module alongside `BurnerManager` and `prefundAccount`.