### PR TITLE
Fix model name generate logic in generate components script

### DIFF
--- a/packages/core/bin/generateComponents.cjs
+++ b/packages/core/bin/generateComponents.cjs
@@ -55,7 +55,7 @@ manifest.models.forEach((model) => {
     let result = model.name.split("::").pop().split("_");
     let modelName = result
         .map((part) => {
-            return part === part.toLowerCase() && part.length > 2
+            return part === part.toLowerCase() && part.length > 1
                 ? part.charAt(0).toUpperCase() + part.slice(1)
                 : part.toUpperCase();
         })


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #
https://github.com/dojoengine/dojo.js/issues/93

## Introduced changes

<!-- A brief description of the changes -->
generateComponents script generates incorrect model name if there is a two character word in model name


for example, for model file `player_at_position`, it generates `PlayerATPosition`, it should be `PlayerAtPosition`
-

## Checklist

<!-- Make sure all of these are complete -->

-   [x] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code
