### PR TITLE
chore: support v1 accounts

### DIFF
--- a/examples/react/react-app/src/dojo/DojoContext.tsx
+++ b/examples/react/react-app/src/dojo/DojoContext.tsx
@@ -37,7 +37,7 @@ export const DojoProvider = ({
     );
 
     const masterAccount = useMemo(
-        () => new Account(rpcProvider, masterAddress, masterPrivateKey),
+        () => new Account(rpcProvider, masterAddress, masterPrivateKey, "1"),
         [rpcProvider, masterAddress, masterPrivateKey]
     );
 

--- a/examples/react/react-phaser-example/src/dojo/createBurner.ts
+++ b/examples/react/react-phaser-example/src/dojo/createBurner.ts
@@ -14,7 +14,8 @@ export const createBurner = async ({ ...config }: Config) => {
         masterAccount: new Account(
             rpcProvider,
             config.masterAddress,
-            config.masterPrivateKey
+            config.masterPrivateKey,
+            "1"
         ),
         accountClassHash: config.accountClassHash,
         rpcProvider,

--- a/packages/core/src/provider/DojoProvider.ts
+++ b/packages/core/src/provider/DojoProvider.ts
@@ -153,14 +153,16 @@ export class DojoProvider extends Provider {
             const nonce = await account?.getNonce();
 
             return await account?.execute(
-                {
-                    contractAddress: getContractByName(
-                        this.manifest,
-                        contract_name
-                    ),
-                    entrypoint: call,
-                    calldata: calldata,
-                },
+                [
+                    {
+                        contractAddress: getContractByName(
+                            this.manifest,
+                            contract_name
+                        ),
+                        entrypoint: call,
+                        calldata: calldata,
+                    },
+                ],
                 undefined,
                 {
                     maxFee: 0, // TODO: Update this value as needed.

--- a/packages/core/src/provider/DojoProvider.ts
+++ b/packages/core/src/provider/DojoProvider.ts
@@ -8,6 +8,7 @@ import {
     AllowArray,
     Call,
     num,
+    Result,
     CallContractResponse,
 } from "starknet";
 import { Provider } from "./provider";
@@ -158,7 +159,7 @@ export class DojoProvider extends Provider {
                         contractAddress: getContractByName(
                             this.manifest,
                             contract_name
-                        ),
+                        )?.address,
                         entrypoint: call,
                         calldata: calldata,
                     },
@@ -235,7 +236,7 @@ export class DojoProvider extends Provider {
     /**
      * Calls a function with the given parameters.
      *
-     * @param {string} contract - The contract to call.
+     * @param {string} contract_name - The contract to call.
      * @param {string} call - The function to call.
      * @returns {Promise<CallContractResponse>} - A promise that resolves to the response of the function call.
      */
@@ -246,15 +247,40 @@ export class DojoProvider extends Provider {
     ): Promise<CallContractResponse> {
         try {
             return await this.provider.callContract({
-                contractAddress: getContractByName(
-                    this.manifest,
-                    contract_name
-                ),
+                contractAddress: getContractByName(this.manifest, contract_name)
+                    ?.address,
                 entrypoint: call,
                 calldata,
             });
         } catch (error) {
             throw new Error(`Failed to call: ${error}`);
+        }
+    }
+    /**
+     * Calls a function with the given parameters and return parsed results.
+     *
+     * @param {string} contract_name - The contract to call.
+     * @param {string} call - The function to call.
+     * @returns {Promise<Result>} - A promise that resolves to the response of the function call.
+     */
+    public async callContract(
+        contract_name: string,
+        call: string,
+        calldata?: num.BigNumberish[]
+    ): Promise<Result> {
+        try {
+            const contractInfos = getContractByName(
+                this.manifest,
+                contract_name
+            );
+            const contract = new Contract(
+                contractInfos.abi,
+                contractInfos.address,
+                this.provider
+            );
+            return await contract.call(call, calldata);
+        } catch (error) {
+            throw new Error(`Failed to callContract: ${error}`);
         }
     }
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -7,16 +7,13 @@
  *
  */
 export const getContractByName = (manifest: any, name: string) => {
-    return (
-        manifest.contracts.find((contract: any) => {
-            const nameParts = contract.name.split("::");
-            // Check if the last part matches or if the full name matches
-            return (
-                nameParts[nameParts.length - 1] === name ||
-                contract.name === name
-            );
-        })?.address || ""
-    );
+    return manifest.contracts.find((contract: any) => {
+        const nameParts = contract.name.split("::");
+        // Check if the last part matches or if the full name matches
+        return (
+            nameParts[nameParts.length - 1] === name || contract.name === name
+        );
+    });
 };
 
 /**

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -3,13 +3,13 @@ import { getContractByName, parseModelName } from "../utils";
 import manifest from "./manifest.json";
 
 test("get address by contract name", () => {
-    expect(getContractByName(manifest, "actions")).toBe(
+    expect(getContractByName(manifest, "actions")?.address).toBe(
         "0x152dcff993befafe5001975149d2c50bd9621da7cbaed74f68e7d5e54e65abc"
     );
 
-    expect(getContractByName(manifest, "dojo_examples::actions::actions")).toBe(
-        "0x152dcff993befafe5001975149d2c50bd9621da7cbaed74f68e7d5e54e65abc"
-    );
+    expect(
+        getContractByName(manifest, "dojo_examples::actions::actions")?.address
+    ).toBe("0x152dcff993befafe5001975149d2c50bd9621da7cbaed74f68e7d5e54e65abc");
 });
 
 test("model name parse", () => {

--- a/packages/create-burner/src/manager/burnerManager.ts
+++ b/packages/create-burner/src/manager/burnerManager.ts
@@ -20,7 +20,8 @@ import { prefundAccount } from "./prefundAccount";
  *  const masterAccount = new Account(
  *      rpcProvider,
  *      import.meta.env.VITE_PUBLIC_MASTER_ADDRESS!,
- *      import.meta.env.VITE_PUBLIC_MASTER_PRIVATE_KEY!
+ *      import.meta.env.VITE_PUBLIC_MASTER_PRIVATE_KEY!,
+ *      "1"
  *   );
  *
  *   const burnerManager = new BurnerManager({
@@ -90,7 +91,8 @@ export class BurnerManager {
                 this.account = new Account(
                     this.provider,
                     address,
-                    storage[address].privateKey
+                    storage[address].privateKey,
+                    "1"
                 );
                 return;
             }
@@ -146,7 +148,8 @@ export class BurnerManager {
         this.account = new Account(
             this.provider,
             address,
-            storage[address].privateKey
+            storage[address].privateKey,
+            "1"
         );
     }
 
@@ -156,7 +159,12 @@ export class BurnerManager {
             throw new Error("burner not found");
         }
 
-        return new Account(this.provider, address, storage[address].privateKey);
+        return new Account(
+            this.provider,
+            address,
+            storage[address].privateKey,
+            "1"
+        );
     }
 
     clear(): void {
@@ -170,7 +178,8 @@ export class BurnerManager {
                 return new Account(
                     this.provider,
                     address,
-                    storage[address].privateKey
+                    storage[address].privateKey,
+                    "1"
                 );
             }
         }
@@ -192,7 +201,6 @@ export class BurnerManager {
         if (!this.masterAccount) {
             throw new Error("wallet account not found");
         }
-
         try {
             await prefundAccount(address, this.masterAccount);
         } catch (e) {
@@ -206,7 +214,7 @@ export class BurnerManager {
         };
 
         // deploy burner
-        const burner = new Account(this.provider, address, privateKey);
+        const burner = new Account(this.provider, address, privateKey, "1");
 
         const nonce = await this.account?.getNonce();
 

--- a/packages/create-burner/src/manager/prefundAccount.ts
+++ b/packages/create-burner/src/manager/prefundAccount.ts
@@ -32,10 +32,9 @@ export const prefundAccount = async (
 
         // Retrieve the nonce for the account to avoid transaction collisions
         const nonce = await account.getNonce();
-
         // Initiate the transaction
         const { transaction_hash } = await account.execute(
-            transferOptions,
+            [transferOptions],
             undefined,
             {
                 nonce,


### PR DESCRIPTION
- specify version "1" for `new Account( ...`
- use execute with an `Array<Call>`

- change `getContractByName` to return contract instead of address
- add callContract method on DojoProvider using abi to parse response
