### PR TITLE
Update get() method type and add getActiveAccount

### DIFF
--- a/packages/create-burner/src/types/index.ts
+++ b/packages/create-burner/src/types/index.ts
@@ -23,11 +23,12 @@ export interface BurnerManagerOptions {
 export interface BurnerAccount {
     create: () => void;
     list: () => Burner[];
-    get: (address: string) => void;
+    get: (address: string) => Account;
     account: Account;
     select: (address: string) => void;
     isDeploying: boolean;
     clear: () => void;
     copyToClipboard: () => Promise<void>;
     applyFromClipboard: () => Promise<void>;
+    getActiveAccount: () => Account | null;
 }


### PR DESCRIPTION
I noticed that some types for the burnerManager could be updated. get() and getActiveAccount()