### PR TITLE
u64 as RecsType.BigInt instead of RecsType.Number

### DIFF
--- a/packages/core/bin/generateComponents.cjs
+++ b/packages/core/bin/generateComponents.cjs
@@ -56,7 +56,7 @@ const cairoToRecsType = {
     u8: "RecsType.Number",
     u16: "RecsType.Number",
     u32: "RecsType.Number",
-    u64: "RecsType.Number",
+    u64: "RecsType.BigInt",
     usize: "RecsType.Number",
     u128: "RecsType.BigInt",
     u256: "RecsType.BigInt",


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #143

## Introduced changes

<!-- A brief description of the changes -->

Follow up to https://github.com/dojoengine/dojo/pull/1532, u64 are now mapped as RecsType.BigInt instead of RecsType.Number

## Checklist

<!-- Make sure all of these are complete -->

-   [x] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [ ] Performed self-review of the code
