### PR TITLE
fix: updated type of account in burner

### DIFF
--- a/packages/create-burner/src/types/index.ts
+++ b/packages/create-burner/src/types/index.ts
@@ -25,7 +25,7 @@ export interface BurnerAccount {
     create: () => void;
     list: () => Burner[];
     get: (address: string) => AccountInterface;
-    account: AccountInterface;
+    account: Account;
     select: (address: string) => void;
     isDeploying: boolean;
     clear: () => void;


### PR DESCRIPTION
## Introduced changes

<!-- A brief description of the changes -->

- The type of the returned `account` in `create-burner` was set to `AccountInterface`, while it actually was an `Account` (which is a superset of `AccountInterface` anyway)

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code
