### PR TITLE
Burner build fix

### DIFF
--- a/packages/create-burner/src/manager/burnerManager.ts
+++ b/packages/create-burner/src/manager/burnerManager.ts
@@ -342,6 +342,20 @@ export class BurnerManager {
                     maxFee: 0, // TODO: update
                 }
             );
+            deployTx = transaction_hash;
+        } catch (error) {
+            this.updateIsDeploying(false);
+            throw error;
+        }
+
+        // check if account is already deployed
+        let isDeployed = false;
+        try {
+            isDeployed = await this.isBurnerDeployed(deployTx);
+        } catch {}
+
+        // wait to deploy
+        if (!isDeployed) {
             const receipt = await this.masterAccount.waitForTransaction(
                 deployTx,
                 {
@@ -351,11 +365,6 @@ export class BurnerManager {
             if (!receipt) {
                 throw new Error("Transaction did not complete successfully.");
             }
-
-            deployTx = transaction_hash;
-        } catch (error) {
-            this.updateIsDeploying(false);
-            throw error;
         }
 
         const storage = this.getBurnerStorage();

--- a/packages/create-burner/src/types/index.ts
+++ b/packages/create-burner/src/types/index.ts
@@ -47,8 +47,8 @@ export interface BurnerAccount {
 }
 
 export interface BurnerCreateOptions {
-    secret: string;
-    index: number;
+    secret?: string;
+    index?: number;
     metadata?: any;
     prefundedAmount?: string;
 }

--- a/packages/create-burner/src/utils/keyDerivation.ts
+++ b/packages/create-burner/src/utils/keyDerivation.ts
@@ -1,5 +1,4 @@
-import { hexToBytes } from "@noble/curves/abstract/utils";
-import { ec, encode } from "starknet";
+import { ec, encode, num } from "starknet";
 import { HDKey } from "@scure/bip32";
 
 //
@@ -29,8 +28,7 @@ export function derivePrivateKeyFromSeed(
     if (!secret) {
         throw "seed is undefined";
     }
-    const hex = encode.sanitizeBytes(encode.removeHexPrefix(secret));
-    const masterNode = HDKey.fromMasterSeed(hexToBytes(hex));
+    const masterNode = HDKey.fromMasterSeed(num.hexToBytes(secret));
     const childNode = masterNode.derive(getPathForIndex(index));
     if (!childNode.privateKey) {
         throw "childNode.privateKey is undefined";

--- a/packages/create-burner/test/manager/burnerManager.test.ts
+++ b/packages/create-burner/test/manager/burnerManager.test.ts
@@ -1,4 +1,4 @@
-import { shortString } from "starknet";
+import { shortString, validateAndParseAddress } from "starknet";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Storage from "../../src/utils/storage";
 import { getBurnerManager } from "../mocks/mocks"; // Adjust the path as necessary
@@ -216,50 +216,75 @@ it("generateKeysAndAddress", async () => {
         index: 1,
     };
 
-    expect(burnerManager.generateKeysAndAddress(wallet1_index0)).toStrictEqual(
+    const keys_random = burnerManager.generateKeysAndAddress();
+    const keys_wallet1_index0 =
+        burnerManager.generateKeysAndAddress(wallet1_index0);
+    const keys_wallet1_index1 =
+        burnerManager.generateKeysAndAddress(wallet1_index1);
+    const keys_wallet1_index2 =
+        burnerManager.generateKeysAndAddress(wallet1_index2);
+    const keys_wallet2_index0 =
+        burnerManager.generateKeysAndAddress(wallet2_index0);
+    const keys_wallet2_index1 =
+        burnerManager.generateKeysAndAddress(wallet2_index1);
+
+    // generated keys are valid
+    expect(BigInt(keys_random.privateKey)).toEqual(
+        BigInt(validateAndParseAddress(keys_random.privateKey))
+    );
+    expect(BigInt(keys_random.publicKey)).toEqual(
+        BigInt(validateAndParseAddress(keys_random.publicKey))
+    );
+    expect(BigInt(keys_random.address)).toEqual(
+        BigInt(validateAndParseAddress(keys_random.address))
+    );
+    expect(BigInt(keys_wallet1_index0.privateKey)).toEqual(
+        BigInt(validateAndParseAddress(keys_wallet1_index0.privateKey))
+    );
+    expect(BigInt(keys_wallet1_index0.publicKey)).toEqual(
+        BigInt(validateAndParseAddress(keys_wallet1_index0.publicKey))
+    );
+    expect(BigInt(keys_wallet1_index0.address)).toEqual(
+        BigInt(validateAndParseAddress(keys_wallet1_index0.address))
+    );
+
+    // random are not deterministic
+    expect(keys_random).not.toStrictEqual(
+        burnerManager.generateKeysAndAddress()
+    );
+
+    // indexed are deterministic
+    expect(keys_wallet1_index0).toStrictEqual(
         burnerManager.generateKeysAndAddress(wallet1_index0)
     );
-    expect(burnerManager.generateKeysAndAddress(wallet1_index1)).toStrictEqual(
+    expect(keys_wallet1_index1).toStrictEqual(
         burnerManager.generateKeysAndAddress(wallet1_index1)
     );
-    expect(burnerManager.generateKeysAndAddress(wallet1_index2)).toStrictEqual(
+    expect(keys_wallet1_index2).toStrictEqual(
         burnerManager.generateKeysAndAddress(wallet1_index2)
     );
-    expect(
-        burnerManager.generateKeysAndAddress(wallet1_index0)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet1_index1));
-    expect(
-        burnerManager.generateKeysAndAddress(wallet1_index1)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet1_index2));
-
-    expect(burnerManager.generateKeysAndAddress(wallet2_index0)).toStrictEqual(
+    expect(keys_wallet2_index0).toStrictEqual(
         burnerManager.generateKeysAndAddress(wallet2_index0)
     );
-    expect(burnerManager.generateKeysAndAddress(wallet2_index1)).toStrictEqual(
+    expect(keys_wallet2_index1).toStrictEqual(
         burnerManager.generateKeysAndAddress(wallet2_index1)
     );
-    expect(
-        burnerManager.generateKeysAndAddress(wallet2_index0)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet2_index1));
 
-    expect(
-        burnerManager.generateKeysAndAddress(wallet1_index0)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet2_index0));
-    expect(
-        burnerManager.generateKeysAndAddress(wallet1_index0)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet2_index1));
-    expect(
-        burnerManager.generateKeysAndAddress(wallet1_index1)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet2_index0));
-    expect(
-        burnerManager.generateKeysAndAddress(wallet1_index1)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet2_index1));
-    expect(
-        burnerManager.generateKeysAndAddress(wallet1_index2)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet2_index0));
-    expect(
-        burnerManager.generateKeysAndAddress(wallet1_index2)
-    ).not.toStrictEqual(burnerManager.generateKeysAndAddress(wallet2_index1));
+    // indexes per wallet are unique
+    expect(keys_wallet1_index0).not.toStrictEqual(keys_random);
+    expect(keys_wallet1_index0).not.toStrictEqual(keys_wallet1_index1);
+    expect(keys_wallet1_index0).not.toStrictEqual(keys_wallet2_index0);
+    expect(keys_wallet1_index0).not.toStrictEqual(keys_wallet2_index1);
+    expect(keys_wallet1_index1).not.toStrictEqual(keys_wallet1_index2);
+    expect(keys_wallet1_index1).not.toStrictEqual(keys_random);
+    expect(keys_wallet1_index1).not.toStrictEqual(keys_wallet2_index0);
+    expect(keys_wallet1_index1).not.toStrictEqual(keys_wallet2_index1);
+    expect(keys_wallet1_index2).not.toStrictEqual(keys_wallet2_index0);
+    expect(keys_wallet1_index2).not.toStrictEqual(keys_random);
+    expect(keys_wallet1_index2).not.toStrictEqual(keys_wallet2_index1);
+    expect(keys_wallet2_index0).not.toStrictEqual(keys_wallet2_index1);
+    expect(keys_wallet2_index0).not.toStrictEqual(keys_random);
+    expect(keys_wallet2_index1).not.toStrictEqual(keys_random);
 });
 
 describe("BurnerManager", () => {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Fixes #186 

## Introduced changes

* CI build fix
* avoid deployment timeout when burner is already deployed
* allow only `prefundedAmount` in `BurnerCreateOptions`
* improved tests

## Checklist

-   [x] Linked relevant issue
-   [x] Updated relevant documentation
-   [x] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code
