### PR TITLE
FIX: setComponentFromEvent() index

### DIFF
--- a/packages/utils/src/utils/index.ts
+++ b/packages/utils/src/utils/index.ts
@@ -47,34 +47,37 @@ export function setComponentFromEvent(
     eventData: string[]
 ) {
     console.log(eventData);
-    // retrieve the component name
-    const componentName = hexToAscii(eventData[0]);
 
-    // retrieve the component from name
-    const component = components[componentName];
+    let index = 0;
 
-    // get keys
-    const keysNumber = parseInt(eventData[1]);
-    let index = 2 + keysNumber + 1;
+    // index 0: get component name
+    const componentName = hexToAscii(eventData[index++]);
 
-    const keys = eventData.slice(2, 2 + keysNumber).map((key) => BigInt(key));
+    // index 1: keys count
+    const keysNumber = parseInt(eventData[index++]);
 
-    // get entityIndex from keys
-    const entityIndex = getEntityIdFromKeys(keys);
-
-    // get values
-    const numberOfValues = parseInt(eventData[index]);
-
+    // index 2: keys
+    const keys = eventData
+        .slice(index, index + keysNumber)
+        .map((key) => BigInt(key));
     const string_keys = keys.map((key) => key.toString());
 
     // get values
+    index += keysNumber;
+    const numberOfValues = parseInt(eventData[index++]);
     const values = eventData.slice(index, index + numberOfValues);
+
+    // retrieve the component from name
+    const component = components[componentName];
 
     // create component object from values with schema
     const componentValues = decodeComponent(component, [
         ...string_keys,
         ...values,
     ]);
+
+    // get entityIndex from keys
+    const entityIndex = getEntityIdFromKeys(keys);
 
     // set component
     setComponent(component, entityIndex, componentValues);


### PR DESCRIPTION
## Introduced changes

Fixes event parse index mismatch introduced in 
https://github.com/dojoengine/dojo.js/commit/c0ea7d9859863474e2bdd37d5193aa52853b8ce4

The bug was in fact on another line, increasing 1 too many:

https://github.com/dojoengine/dojo.js/blob/c0ea7d9859863474e2bdd37d5193aa52853b8ce4/packages/utils/src/utils/index.ts#L58

For better clarity, I restructured how the index is incremented and consumed, event by event.

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code
-   [x] Tested with `react-app` example