### PR TITLE
fix: phaser ui due to noise in mapSystem

### DIFF
--- a/examples/react/react-phaser-example/src/phaser/systems/mapSystem.ts
+++ b/examples/react/react-phaser-example/src/phaser/systems/mapSystem.ts
@@ -17,11 +17,11 @@ export function mapSystem(layer: PhaserLayer) {
     for (let x = 0; x < 50; x++) {
         for (let y = 0; y < 50; y++) {
             const coord = { x, y };
-            const noiseInput = new Float64Array([
+            const noiseInput = [
                 x / MAP_AMPLITUDE,
                 0,
                 y / MAP_AMPLITUDE,
-            ]);
+            ];
             // Get a noise value between 0 and 100
             const seed = Math.floor(((snoise(noiseInput) + 1) / 2) * 100);
 


### PR DESCRIPTION
## Issue

When launching the React Phaser example, we only get a grass ground rendered, no other tiles, no buttons.
In the logs, we see 
`TypeError: Unexpected type of argument in function dot (expected: Array or DenseMatrix or SparseMatrix or Matrix, actual: any, index: 0)`.

I did not create an issue, please let me know if I should.

## Origin

In 62429f51 we went back from using WASM to JS implementation of `snoise` (from utils-wasm to utils, 
partially reverting 4ddc4f36). 
Mathjs' `dot` however doesn't support `Float64Array`. 

## Introduced changes

FIX: restore the use of a simple array.
