### PR TITLE
fix: build torii-client with tsup

### DIFF
--- a/packages/torii-client/package.json
+++ b/packages/torii-client/package.json
@@ -8,7 +8,7 @@
     "main": "dist/index.js",
     "type": "module",
     "scripts": {
-        "build": "tsc"
+        "build": "tsup --dts-resolve"
     },
     "exports": {
         ".": {


### PR DESCRIPTION

Closes #207 

## Introduced changes

Changes `torii-client` build command from `tsc` to `tsup --dts-resolve`

## Checklist

<!-- Make sure all of these are complete -->

-   [x] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code
-   [x] Build all packages
-   [x] Built all examples
