### PR TITLE
Restore burner accounts

### DIFF
--- a/examples/react/react-app/src/dojo/DojoContext.tsx
+++ b/examples/react/react-app/src/dojo/DojoContext.tsx
@@ -50,6 +50,7 @@ export const DojoProvider = ({
         count,
         copyToClipboard,
         applyFromClipboard,
+        checkIsDeployed,
     } = useBurnerManager({
         burnerManager,
     });
@@ -72,6 +73,7 @@ export const DojoProvider = ({
                     count,
                     copyToClipboard,
                     applyFromClipboard,
+                    checkIsDeployed,
                 },
             }}
         >

--- a/examples/react/react-pwa-app/src/dojo/DojoContext.tsx
+++ b/examples/react/react-pwa-app/src/dojo/DojoContext.tsx
@@ -50,6 +50,7 @@ export const DojoProvider = ({
         count,
         copyToClipboard,
         applyFromClipboard,
+        checkIsDeployed,
     } = useBurnerManager({
         burnerManager,
     });
@@ -72,6 +73,7 @@ export const DojoProvider = ({
                     count,
                     copyToClipboard,
                     applyFromClipboard,
+                    checkIsDeployed,
                 },
             }}
         >

--- a/examples/react/react-threejs/src/dojo/DojoContext.tsx
+++ b/examples/react/react-threejs/src/dojo/DojoContext.tsx
@@ -51,6 +51,7 @@ export const DojoProvider = ({
         count,
         copyToClipboard,
         applyFromClipboard,
+        checkIsDeployed,
     } = useBurnerManager({
         burnerManager,
     });
@@ -73,6 +74,7 @@ export const DojoProvider = ({
                     count,
                     copyToClipboard,
                     applyFromClipboard,
+                    checkIsDeployed,
                 },
             }}
         >

--- a/examples/react/starknet-react-app/src/dojo/DojoContext.tsx
+++ b/examples/react/starknet-react-app/src/dojo/DojoContext.tsx
@@ -72,6 +72,7 @@ export const DojoProvider = ({
         count,
         copyToClipboard,
         applyFromClipboard,
+        checkIsDeployed,
     } = useBurnerManager({
         burnerManager,
     });
@@ -96,6 +97,7 @@ export const DojoProvider = ({
                     count,
                     copyToClipboard,
                     applyFromClipboard,
+                    checkIsDeployed,
                 },
             }}
         >

--- a/packages/create-burner/src/hooks/useBurnerManager.ts
+++ b/packages/create-burner/src/hooks/useBurnerManager.ts
@@ -110,6 +110,20 @@ export const useBurnerManager = ({
     }, [burnerManager]);
 
     /**
+     * Checks if an account has been deployed.
+     *
+     * @param address - The address of the burner account to check.
+     * @param deployTx - Optional deployment transaction hash.
+     * @returns True if account has been deployed.
+     */
+    const checkIsDeployed = useCallback(
+        async (address: string, deployTx?: string): Promise<boolean> => {
+            return burnerManager.isBurnerDeployed(address, deployTx);
+        },
+        [burnerManager]
+    );
+
+    /**
      * Creates a new burner account and sets it as the active account.
      *
      * @param options - (optional) secret seed and index for deterministic accounts.
@@ -184,6 +198,7 @@ export const useBurnerManager = ({
         select,
         deselect,
         remove,
+        checkIsDeployed,
         create,
         listConnectors,
         clear,

--- a/packages/create-burner/src/types/index.ts
+++ b/packages/create-burner/src/types/index.ts
@@ -44,6 +44,7 @@ export interface BurnerAccount {
     applyFromClipboard: () => Promise<void>;
     getActiveAccount?: () => Account | null;
     generateAddressFromSeed?: (options?: BurnerCreateOptions) => string;
+    checkIsDeployed: (address: string, deployTx?: string) => Promise<boolean>;
 }
 
 export interface BurnerCreateOptions {


### PR DESCRIPTION

Closes #209

## Introduced changes

* Adapted the `burnerManager.create()` function to check if the account is already deployed, and if it is, just restore instead of deploying.
* Adapted the `burnerManager.isBurnerDeployed()` to verify if an account is deployed by reading its nonce, instead of the transaction hash. This is required because, at the moment of deployment, the transaction hash is unknown. The current check using transaction has not been modified and is preferred. In the absence of tx_hash, the new nonce method will be used.
* Exposed a new `checkIsDeployed()` function to the `useBurnerManager` hook to allow apps to check if an account is already deployed, for a better onboarding experience.

## Checklist

-   [x] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code
-   [x] Build packages
-   [x] Built examples