### PR TITLE
fix: added SRC acronym to create-components

### DIFF
--- a/packages/core/bin/generateComponents.cjs
+++ b/packages/core/bin/generateComponents.cjs
@@ -6,7 +6,7 @@ const { execSync } = require("child_process");
 
 const parseModelName = (model) => {
     // Define a set of known acronyms
-    const acronyms = new Set(["ERC"]);
+    const acronyms = new Set(["ERC", "SRC"]);
 
     return model.name
         .split("::")


### PR DESCRIPTION

<!-- Reference any GitHub issues resolved by this PR -->

Closes #232 

## Introduced changes

<!-- A brief description of the changes -->

- Added `SRC` acronym for the Origami model `for origami token::components::introspection::src5::src_5_model`, which is named `SRC5Model`.

## Checklist

<!-- Make sure all of these are complete -->

-   [x] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved model name parsing by recognizing the acronym "SRC".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->