### PR TITLE
fix: locked snjs

### DIFF
--- a/examples/react/react-app/package.json
+++ b/examples/react/react-app/package.json
@@ -26,7 +26,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rxjs": "^7.8.1",
-        "starknet": "^6.1.5",
+        "starknet": "6.1.5",
         "vite-plugin-top-level-await": "^1.3.1",
         "vite-plugin-wasm": "^3.2.2"
     },

--- a/examples/react/react-phaser-example/package.json
+++ b/examples/react/react-phaser-example/package.json
@@ -36,7 +36,7 @@
         "react-dom": "^18.2.0",
         "rxjs": "^7.8.1",
         "simplex-noise": "^4.0.1",
-        "starknet": "^6.1.5",
+        "starknet": "6.1.5",
         "styled-components": "^6.0.7",
         "tailwind-merge": "^2.0.0",
         "tailwindcss-animate": "^1.0.7",

--- a/examples/react/react-pwa-app/package.json
+++ b/examples/react/react-pwa-app/package.json
@@ -31,7 +31,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rxjs": "^7.8.1",
-        "starknet": "^6.1.5",
+        "starknet": "6.1.5",
         "vite-plugin-top-level-await": "^1.3.1",
         "vite-plugin-wasm": "^3.2.2"
     },

--- a/examples/react/react-threejs/package.json
+++ b/examples/react/react-threejs/package.json
@@ -47,7 +47,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "rxjs": "^7.8.1",
-        "starknet": "^6.1.5",
+        "starknet": "6.1.5",
         "tailwind-merge": "^2.2.0",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",

--- a/examples/react/starknet-react-app/package.json
+++ b/examples/react/starknet-react-app/package.json
@@ -28,7 +28,7 @@
         "react": "^18",
         "react-dom": "^18",
         "rxjs": "^7.8.1",
-        "starknet": "^6.1.5",
+        "starknet": "6.1.5",
         "vite-plugin-top-level-await": "^1.3.1",
         "vite-plugin-wasm": "^3.2.2"
     },

--- a/examples/vue/vue-app/package.json
+++ b/examples/vue/vue-app/package.json
@@ -18,7 +18,7 @@
         "@dojoengine/torii-client": "workspace:*",
         "@dojoengine/utils": "workspace:*",
         "@latticexyz/utils": "^1.43.0",
-        "starknet": "^6.1.5",
+        "starknet": "6.1.5",
         "vite-plugin-top-level-await": "^1.4.1",
         "vite-plugin-wasm": "^3.3.0",
         "vue": "^3.4.19"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
         }
     },
     "peerDependencies": {
-        "starknet": "^6.1.5"
+        "starknet": "6.1.5"
     },
     "devDependencies": {
         "@dojoengine/torii-client": "workspace:*",

--- a/packages/create-burner/package.json
+++ b/packages/create-burner/package.json
@@ -14,7 +14,7 @@
     "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "starknet": "^6.1.5"
+        "starknet": "6.1.5"
     },
     "exports": {
         ".": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,7 @@
     "license": "MIT",
     "peerDependencies": {
         "react": "^18.2.0",
-        "starknet": "^6.1.5",
+        "starknet": "6.1.5",
         "type-fest": "^2.14.0"
     },
     "exports": {

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -21,7 +21,7 @@
         "typescript": "^5.0.3"
     },
     "peerDependencies": {
-        "starknet": "^6.1.5"
+        "starknet": "6.1.5"
     },
     "dependencies": {
         "@dojoengine/recs": "2.0.13",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,7 +22,7 @@
         "typescript": "^5.0.3"
     },
     "peerDependencies": {
-        "starknet": "^6.1.5"
+        "starknet": "6.1.5"
     },
     "dependencies": {
         "@dojoengine/recs": "2.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,8 +155,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       vite-plugin-top-level-await:
         specifier: ^1.3.1
         version: 1.4.1(rollup@4.18.0)(vite@4.5.3(@types/node@20.14.8)(terser@5.31.1))
@@ -273,8 +273,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       styled-components:
         specifier: ^6.0.7
         version: 6.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -394,8 +394,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       vite-plugin-top-level-await:
         specifier: ^1.3.1
         version: 1.4.1(rollup@2.79.1)(vite@4.5.3(@types/node@20.14.8)(terser@5.31.1))
@@ -560,8 +560,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       tailwind-merge:
         specifier: ^2.2.0
         version: 2.3.0
@@ -682,13 +682,13 @@ importers:
         version: 0.1.7
       '@starknet-react/core':
         specifier: ^2.2.5
-        version: 2.3.0(get-starknet-core@3.3.0(starknet@6.10.0(encoding@0.1.13)))(react@18.3.1)(starknet@6.10.0(encoding@0.1.13))
+        version: 2.3.0(get-starknet-core@3.3.0(starknet@6.1.5(encoding@0.1.13)))(react@18.3.1)(starknet@6.1.5(encoding@0.1.13))
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
       get-starknet-core:
         specifier: ^3.2.0
-        version: 3.3.0(starknet@6.10.0(encoding@0.1.13))
+        version: 3.3.0(starknet@6.1.5(encoding@0.1.13))
       mobx:
         specifier: ^6.9.0
         version: 6.12.4
@@ -705,8 +705,8 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       vite-plugin-top-level-await:
         specifier: ^1.3.1
         version: 1.4.1(rollup@4.18.0)(vite@4.5.3(@types/node@20.14.8)(terser@5.31.1))
@@ -775,8 +775,8 @@ importers:
         specifier: ^1.43.0
         version: 1.43.0(ethers@5.7.2)(mobx@6.12.4)(proxy-deep@3.1.1)(rxjs@7.8.1)(typedoc@0.25.13(typescript@5.5.2))(web3-utils@1.10.4)
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
         version: 1.4.1(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.8)(terser@5.31.1))
@@ -806,8 +806,8 @@ importers:
         specifier: 2.0.13
         version: 2.0.13(typescript@5.5.2)(zod@3.23.8)
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       zod:
         specifier: ^3.22.4
         version: 3.23.8
@@ -841,13 +841,13 @@ importers:
         version: 1.4.0
       '@starknet-react/core':
         specifier: 2.3.0
-        version: 2.3.0(get-starknet-core@3.3.0(starknet@6.10.0(encoding@0.1.13)))(react@18.3.1)(starknet@6.10.0(encoding@0.1.13))
+        version: 2.3.0(get-starknet-core@3.3.0(starknet@6.1.5(encoding@0.1.13)))(react@18.3.1)(starknet@6.1.5(encoding@0.1.13))
       encoding:
         specifier: ^0.1.13
         version: 0.1.13
       get-starknet-core:
         specifier: ^3.2.0
-        version: 3.3.0(starknet@6.10.0(encoding@0.1.13))
+        version: 3.3.0(starknet@6.1.5(encoding@0.1.13))
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
@@ -858,8 +858,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
     devDependencies:
       '@babel/core':
         specifier: ^7.21.4
@@ -948,7 +948,7 @@ importers:
         version: 3.1.3
       get-starknet-core:
         specifier: ^3.2.0
-        version: 3.3.0(starknet@6.10.0(encoding@0.1.13))
+        version: 3.3.0(starknet@6.1.5(encoding@0.1.13))
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
@@ -959,8 +959,8 @@ importers:
         specifier: 7.5.5
         version: 7.5.5
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       type-fest:
         specifier: ^2.14.0
         version: 2.19.0
@@ -1008,8 +1008,8 @@ importers:
         specifier: ^2.0.0-next.11
         version: 2.0.12
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.14.8)(jsdom@24.1.0)(terser@5.31.1)
@@ -1064,8 +1064,8 @@ importers:
         specifier: ^0.2.3
         version: 0.2.3
       starknet:
-        specifier: ^6.1.5
-        version: 6.10.0(encoding@0.1.13)
+        specifier: 6.1.5
+        version: 6.1.5(encoding@0.1.13)
     devDependencies:
       '@types/elliptic':
         specifier: ^6.4.14
@@ -3934,9 +3934,6 @@ packages:
   '@solidity-parser/parser@0.17.0':
     resolution: {integrity: sha512-Nko8R0/kUo391jsEHHxrGM07QFdnPGvlmox4rmH0kNiNAashItAilhy4Mv4pK5gQmW5f4sXAF58fwJbmlkGcVw==}
 
-  '@starknet-io/types-js@0.7.7':
-    resolution: {integrity: sha512-WLrpK7LIaIb8Ymxu6KF/6JkGW1sso988DweWu7p5QY/3y7waBIiPvzh27D9bX5KIJNRDyOoOVoHVEKYUYWZ/RQ==}
-
   '@starknet-react/chains@0.1.7':
     resolution: {integrity: sha512-UNh97I1SvuJKaAhKOmpEk8JcWuZWMlPG/ba2HcvFYL9x/47BKndJ+Da9V+iJFtkHUjreVnajT1snsaz1XMG+UQ==}
 
@@ -6432,9 +6429,6 @@ packages:
     resolution: {integrity: sha512-TG17zIBdjHIyO0CTjkB7lkuvo24OHLrkB/rZSEdspEAcwcysMpZOVgwrNPIzD89kU8gZ3m1UANarFNPVLULS5Q==}
     peerDependencies:
       starknet: ^5.18.0
-
-  get-starknet-core@4.0.0:
-    resolution: {integrity: sha512-6pLmidQZkC3wZsrHY99grQHoGpuuXqkbSP65F8ov1/JsEI8DDLkhsAuLCKFzNOK56cJp+f1bWWfTJ57e9r5eqQ==}
 
   get-stream@6.0.0:
     resolution: {integrity: sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==}
@@ -9402,8 +9396,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  starknet@6.10.0:
-    resolution: {integrity: sha512-Zlo39V37dytBcqHlWpyLkEH4lXGRMaH7ST4yDGSGxkgxlJ11xW7P7abpWnB87Qn9SdgEzUEDLyM3TeBVTsdtYA==}
+  starknet@6.1.5:
+    resolution: {integrity: sha512-mhkadsHf3uoqax0UEfb7VMdfbY5UK8DAlDMnEVKYtG9PstE3ajLWoTu2KKdG0F2CWtPlYqTejuJ0fOEhwIwoPA==}
 
   stats-gl@2.2.8:
     resolution: {integrity: sha512-94G5nZvduDmzxBS7K0lYnynYwreZpkknD8g5dZmU6mpwIhy3caCrjAm11Qm1cbyx7mqix7Fp00RkbsonzKWnoQ==}
@@ -14330,19 +14324,17 @@ snapshots:
 
   '@solidity-parser/parser@0.17.0': {}
 
-  '@starknet-io/types-js@0.7.7': {}
-
   '@starknet-react/chains@0.1.7': {}
 
-  '@starknet-react/core@2.3.0(get-starknet-core@3.3.0(starknet@6.10.0(encoding@0.1.13)))(react@18.3.1)(starknet@6.10.0(encoding@0.1.13))':
+  '@starknet-react/core@2.3.0(get-starknet-core@3.3.0(starknet@6.1.5(encoding@0.1.13)))(react@18.3.1)(starknet@6.1.5(encoding@0.1.13))':
     dependencies:
       '@starknet-react/chains': 0.1.7
       '@tanstack/react-query': 5.45.1(react@18.3.1)
       eventemitter3: 5.0.1
-      get-starknet-core: 3.3.0(starknet@6.10.0(encoding@0.1.13))
+      get-starknet-core: 3.3.0(starknet@6.1.5(encoding@0.1.13))
       immutable: 4.3.6
       react: 18.3.1
-      starknet: 6.10.0(encoding@0.1.13)
+      starknet: 6.1.5(encoding@0.1.13)
       zod: 3.23.8
 
   '@storybook/addon-actions@7.6.20':
@@ -17702,14 +17694,10 @@ snapshots:
 
   get-port@5.1.1: {}
 
-  get-starknet-core@3.3.0(starknet@6.10.0(encoding@0.1.13)):
+  get-starknet-core@3.3.0(starknet@6.1.5(encoding@0.1.13)):
     dependencies:
       '@module-federation/runtime': 0.1.21
-      starknet: 6.10.0(encoding@0.1.13)
-
-  get-starknet-core@4.0.0:
-    dependencies:
-      '@starknet-io/types-js': 0.7.7
+      starknet: 6.1.5(encoding@0.1.13)
 
   get-stream@6.0.0: {}
 
@@ -20638,19 +20626,16 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starknet@6.10.0(encoding@0.1.13):
+  starknet@6.1.5(encoding@0.1.13):
     dependencies:
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
+      '@noble/curves': 1.3.0
       '@scure/base': 1.1.7
       '@scure/starknet': 1.0.0
       abi-wan-kanabi: 2.2.2
       fetch-cookie: 3.0.1
-      get-starknet-core: 4.0.0
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
       lossless-json: 4.0.1
       pako: 2.1.0
-      starknet-types-07: '@starknet-io/types-js@0.7.7'
       ts-mixer: 6.0.4
       url-join: 4.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
- locks starknetjs to working version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized the version constraint of the `starknet` dependency to `"6.1.5"` across multiple React and Vue projects, and various internal packages, ensuring consistent dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->