### PR TITLE
fix: manifest path

### DIFF
--- a/examples/react/react-app/dojoConfig.ts
+++ b/examples/react/react-app/dojoConfig.ts
@@ -1,4 +1,4 @@
-import manifest from "../../dojo-starter/manifests/dev/manifest.json";
+import manifest from "../dojo-starter/manifests/dev/manifest.json";
 import { createDojoConfig } from "@dojoengine/core";
 
 export const dojoConfig = createDojoConfig({


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes
This changes the manifest path. I tried using the dojo starter repo and this solved the issue for me.
<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the import path for the `manifest.json` file in configuration to reflect the correct directory structure.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->