### PR TITLE
fix: enums as strings

### DIFF
--- a/examples/react/react-app/src/App.tsx
+++ b/examples/react/react-app/src/App.tsx
@@ -105,22 +105,27 @@ function App() {
             <div className="card">
                 <button onClick={() => spawn(account.account)}>Spawn</button>
                 <div>
-                    Moves Left: {moves ? `${moves.remaining}` : "Need to Spawn"}
+                    Moves Left:{" "}
+                    <b>{moves ? `${moves.remaining}` : "Need to Spawn"}</b>
                 </div>
                 <div>
                     Position:{" "}
-                    {position
-                        ? `${position?.vec.x}, ${position?.vec.y}`
-                        : "Need to Spawn"}
+                    <b>
+                        {position
+                            ? `${position.vec.x}, ${position.vec.y}`
+                            : "Need to Spawn"}
+                    </b>
                 </div>
 
-                <div>{moves && moves.last_direction}</div>
+                <div>
+                    Last Direction: <b>{moves?.last_direction}</b>
+                </div>
 
                 <div>
-                    <div>Available Positions</div>
+                    <div>Available Positions:</div>
                     {directions?.directions.map((a: any, index: any) => (
                         <div key={index} className="">
-                            {a}
+                            <b>{a}</b>
                         </div>
                     ))}
                 </div>

--- a/examples/react/react-app/src/dojo/generated/contractComponents.ts
+++ b/examples/react/react-app/src/dojo/generated/contractComponents.ts
@@ -31,7 +31,7 @@ export function defineContractComponents(world: World) {
                 {
                     player: RecsType.BigInt,
                     remaining: RecsType.Number,
-                    last_direction: RecsType.Number,
+                    last_direction: RecsType.String,
                     can_move: RecsType.Boolean,
                 },
                 {

--- a/examples/react/react-phaser-example/src/dojo/contractComponents.ts
+++ b/examples/react/react-phaser-example/src/dojo/contractComponents.ts
@@ -10,7 +10,7 @@ export function defineContractComponents(world: World) {
                 {
                     player: RecsType.BigInt,
                     remaining: RecsType.Number,
-                    last_direction: RecsType.Number,
+                    last_direction: RecsType.String,
                 },
                 {
                     metadata: {

--- a/examples/react/react-phaser-example/src/dojo/generated/contractComponents.ts
+++ b/examples/react/react-phaser-example/src/dojo/generated/contractComponents.ts
@@ -18,7 +18,7 @@ export function defineContractComponents(world: World) {
                 {
                     player: RecsType.BigInt,
                     remaining: RecsType.Number,
-                    last_direction: RecsType.Number,
+                    last_direction: RecsType.String,
                 },
                 {
                     metadata: {

--- a/examples/react/react-pwa-app/src/App.tsx
+++ b/examples/react/react-pwa-app/src/App.tsx
@@ -104,13 +104,19 @@ function App() {
             <div className="card">
                 <button onClick={() => spawn(account.account)}>Spawn</button>
                 <div>
-                    Moves Left: {moves ? `${moves.remaining}` : "Need to Spawn"}
+                    Moves Left:{" "}
+                    <b>{moves ? `${moves.remaining}` : "Need to Spawn"}</b>
                 </div>
                 <div>
                     Position:{" "}
-                    {position
-                        ? `${position.vec.x}, ${position.vec.y}`
-                        : "Need to Spawn"}
+                    <b>
+                        {position
+                            ? `${position.vec.x}, ${position.vec.y}`
+                            : "Need to Spawn"}
+                    </b>
+                </div>
+                <div>
+                    Last Direction: <b>{moves?.last_direction}</b>
                 </div>
             </div>
 

--- a/examples/react/react-pwa-app/src/dojo/createSystemCalls.ts
+++ b/examples/react/react-pwa-app/src/dojo/createSystemCalls.ts
@@ -35,7 +35,7 @@ export function createSystemCalls(
             value: {
                 player: BigInt(entityId),
                 remaining: 100,
-                last_direction: 0,
+                last_direction: "",
             },
         });
 

--- a/examples/react/react-pwa-app/src/dojo/generated/contractComponents.ts
+++ b/examples/react/react-pwa-app/src/dojo/generated/contractComponents.ts
@@ -18,7 +18,7 @@ export function defineContractComponents(world: World) {
                 {
                     player: RecsType.BigInt,
                     remaining: RecsType.Number,
-                    last_direction: RecsType.Number,
+                    last_direction: RecsType.String,
                 },
                 {
                     metadata: {

--- a/examples/react/react-threejs/src/dojo/createSystemCalls.ts
+++ b/examples/react/react-threejs/src/dojo/createSystemCalls.ts
@@ -35,7 +35,7 @@ export function createSystemCalls(
             value: {
                 player: BigInt(entityId),
                 remaining: 100,
-                last_direction: 0,
+                last_direction: "",
             },
         });
 

--- a/examples/react/react-threejs/src/dojo/generated/contractComponents.ts
+++ b/examples/react/react-threejs/src/dojo/generated/contractComponents.ts
@@ -18,7 +18,7 @@ export function defineContractComponents(world: World) {
                 {
                     player: RecsType.BigInt,
                     remaining: RecsType.Number,
-                    last_direction: RecsType.Number,
+                    last_direction: RecsType.String,
                 },
                 {
                     metadata: {

--- a/examples/react/starknet-react-app/src/App.tsx
+++ b/examples/react/starknet-react-app/src/App.tsx
@@ -107,13 +107,19 @@ function App() {
             <div className="card">
                 <button onClick={() => spawn(account.account)}>Spawn</button>
                 <div>
-                    Moves Left: {moves ? `${moves.remaining}` : "Need to Spawn"}
+                    Moves Left:{" "}
+                    <b>{moves ? `${moves.remaining}` : "Need to Spawn"}</b>
                 </div>
                 <div>
                     Position:{" "}
-                    {position
-                        ? `${position.vec.x}, ${position.vec.y}`
-                        : "Need to Spawn"}
+                    <b>
+                        {position
+                            ? `${position.vec.x}, ${position.vec.y}`
+                            : "Need to Spawn"}
+                    </b>
+                </div>
+                <div>
+                    Last Direction: <b>{moves?.last_direction}</b>
                 </div>
             </div>
 

--- a/examples/react/starknet-react-app/src/dojo/createSystemCalls.ts
+++ b/examples/react/starknet-react-app/src/dojo/createSystemCalls.ts
@@ -35,7 +35,7 @@ export function createSystemCalls(
             value: {
                 player: BigInt(entityId),
                 remaining: 100,
-                last_direction: 0,
+                last_direction: "",
             },
         });
 

--- a/examples/react/starknet-react-app/src/dojo/generated/contractComponents.ts
+++ b/examples/react/starknet-react-app/src/dojo/generated/contractComponents.ts
@@ -18,7 +18,7 @@ export function defineContractComponents(world: World) {
                 {
                     player: RecsType.BigInt,
                     remaining: RecsType.Number,
-                    last_direction: RecsType.Number,
+                    last_direction: RecsType.String,
                 },
                 {
                     metadata: {

--- a/examples/vue/vue-app/src/dojo/createSystemCalls.ts
+++ b/examples/vue/vue-app/src/dojo/createSystemCalls.ts
@@ -35,7 +35,7 @@ export function createSystemCalls(
             value: {
                 player: BigInt(entityId),
                 remaining: 100,
-                last_direction: 0,
+                last_direction: "",
             },
         });
 

--- a/examples/vue/vue-app/src/dojo/generated/contractComponents.ts
+++ b/examples/vue/vue-app/src/dojo/generated/contractComponents.ts
@@ -18,7 +18,7 @@ export function defineContractComponents(world: World) {
                 {
                     player: RecsType.BigInt,
                     remaining: RecsType.Number,
-                    last_direction: RecsType.Number,
+                    last_direction: RecsType.String,
                 },
                 {
                     metadata: {

--- a/packages/core/bin/generateComponents.cjs
+++ b/packages/core/bin/generateComponents.cjs
@@ -177,7 +177,7 @@ function parseSchemaStruct(content, types, customTypes) {
 }
 
 function parseSchemaEnum(_schema) {
-    return "RecsType.Number";
+    return "RecsType.String";
 }
 
 function parseSchemaTuple(content, types, customTypes) {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #238

Depends on Torii behavior resolution in [dojo issue #2188](https://github.com/dojoengine/dojo/issues/2188). If Torii is correct, this PR can go on.

## Introduced changes

- Parse enum types as strings

## Checklist

<!-- Make sure all of these are complete -->

-   [x] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced user interface with bold formatting for key gameplay elements such as "Moves Left," "Position," and "Last Direction."

- **Bug Fixes**
	- Updated data type for the `last_direction` property from numeric to string across various components, improving clarity and usability.

- **Chores**
	- Adjusted internal structure of system calls related to `last_direction` to support string representation instead of numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->