### PR TITLE
fix: remove husky deprecation warning

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 pnpm run prettier-check


### PR DESCRIPTION
## Introduced changes

removed deprecation warning on husky git hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the commit message hook to streamline the linting process.
	- Updated the pre-commit hook to focus solely on executing the prettier-check command, enhancing clarity and reducing complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->