### PR TITLE
fix: remove ts error while building packages

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
+    ...(tsupConfig as Options),
     minify: false,
     splitting: false,
 });

--- a/packages/create-burner/tsup.config.ts
+++ b/packages/create-burner/tsup.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
+    ...(tsupConfig as Options),
     minify: false,
     splitting: false,
 });

--- a/packages/create-dojo/tsup.config.ts
+++ b/packages/create-dojo/tsup.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
-    minify: false,
-    splitting: false,
-    outDir: "./bin",
+  ...(tsupConfig as Options),
+  minify: false,
+  splitting: false,
+  outDir: "./bin",
 });

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
+    ...(tsupConfig as Options),
     minify: false,
     splitting: false,
 });

--- a/packages/state/tsup.config.ts
+++ b/packages/state/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
+    ...(tsupConfig as Options),
 });

--- a/packages/torii-client/tsup.config.ts
+++ b/packages/torii-client/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
+    ...(tsupConfig as Options),
 });

--- a/packages/torii-wasm/tsup.config.ts
+++ b/packages/torii-wasm/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
+    ...(tsupConfig as Options),
 });

--- a/packages/utils-wasm/tsup.config.ts
+++ b/packages/utils-wasm/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
+    ...(tsupConfig as Options),
 });

--- a/packages/utils/tsup.config.ts
+++ b/packages/utils/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { defineConfig, Options } from "tsup";
 import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
-    ...tsupConfig,
+    ...(tsupConfig as Options),
 });


### PR DESCRIPTION
## Introduced changes

I've had weird issues (with up to date project) where tsupConfig was imported but was not recognized as an `Options` type.

As this is not very important piece of software and not much prone to change, I've forced type so that`pnpm build` works without any ts errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Enhanced type safety across various configuration files, reducing potential runtime errors related to configuration mismatches.

- **New Features**
	- Improved maintainability and clarity of configuration setup with explicit type assertions, ensuring adherence to the expected structure.

- **Chores**
	- Updated import statements to include the `Options` type from the `tsup` package in multiple configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->