### PR TITLE
feat: allow wasm in nodejs

### DIFF
--- a/packages/torii-wasm/build.sh
+++ b/packages/torii-wasm/build.sh
@@ -3,13 +3,15 @@
 # Exit immediately if a command exits with a non-zero status
 set -ex
 
-# # Clone the repository
+# Clone the repository
 git clone --depth 1 https://github.com/dojoengine/dojo.c dojo.c
 cd dojo.c
 
-set -ex
+# Build for web (browser)
+npx wasm-pack build --out-dir ../pkg/web --release --target web
 
-npx wasm-pack build --out-dir ../pkg --release
+# Build for Node.js
+npx wasm-pack build --out-dir ../pkg/node --release --target nodejs
 
 # Go back to the parent directory and delete the repository
 cd ..

--- a/packages/torii-wasm/package.json
+++ b/packages/torii-wasm/package.json
@@ -4,22 +4,28 @@
     "description": "Torii wasm bindings for Dojo onchain game engine",
     "author": "",
     "license": "MIT",
-    "main": "./pkg/dojo_c.js",
+    "main": "./pkg/node/dojo_c.js",
+    "browser": "./pkg/web/dojo_c.js",
     "type": "module",
     "scripts": {
         "build-wasm": "sh ./build.sh",
         "build": "npm run build-wasm && tsc"
     },
     "files": [
-        "./pkg/dojo_c_bg.wasm",
-        "./pkg/dojo_c.js",
-        "./pkg/dojo_c_bg.js",
-        "./pkg/dojo_c.d.ts"
+        "./pkg/web/dojo_c_bg.wasm",
+        "./pkg/web/dojo_c.js",
+        "./pkg/web/dojo_c_bg.js",
+        "./pkg/web/dojo_c.d.ts",
+        "./pkg/node/dojo_c_bg.wasm",
+        "./pkg/node/dojo_c.js",
+        "./pkg/node/dojo_c_bg.js",
+        "./pkg/node/dojo_c.d.ts"
     ],
-    "module": "./pkg/dojo_c.js",
-    "types": "./pkg/dojo_c.d.ts",
+    "module": "./pkg/web/dojo_c.js",
+    "types": "./pkg/web/dojo_c.d.ts",
     "sideEffects": [
-        "./pkg/dojo_c.js",
+        "./pkg/web/dojo_c.js",
+        "./pkg/node/dojo_c.js",
         "./pkg/snippets/*"
     ],
     "devDependencies": {


### PR DESCRIPTION
Allows wasm to run in nodejs env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced separate build commands for web browsers and Node.js, enhancing the deployment strategy for WebAssembly packages.
	- Added explicit paths for JavaScript and TypeScript definitions in the package configuration to support multiple environments.

- **Improvements**
	- Enhanced clarity of build commands with descriptive comments in the build script.
	- Updated package configuration to delineate resources for web and Node.js contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->