### PR TITLE
fix: separate model name and namespace on components generator

### DIFF
--- a/packages/core/bin/generateComponents.cjs
+++ b/packages/core/bin/generateComponents.cjs
@@ -82,7 +82,7 @@ manifest.models.forEach((model) => {
     const customTypes = [];
 
     let modelName = model.tag;
-    let modelNameNoNamespace = model.tag.split("-")[1];
+    let [modelNamespace, modelNameNoNamespace] = model.tag.split("-");
 
     try {
         const output = execSync(
@@ -102,7 +102,8 @@ manifest.models.forEach((model) => {
         fileContent += `        ${recsTypeObject},\n`;
         fileContent += `        {\n`;
         fileContent += `          metadata: {\n`;
-        fileContent += `            name: "${modelName}",\n`;
+        fileContent += `            namespace: "${modelNamespace}",\n`;
+        fileContent += `            name: "${modelNameNoNamespace}",\n`;
         fileContent += `            types: ${JSON.stringify(types)},\n`;
         fileContent += `            customTypes: ${JSON.stringify(
             customTypes


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Fixes torii sync on Dojo alpha.9

## Introduced changes

- `generateComponents` fix

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced clarity in model name processing, allowing for better distinction between namespace and model name.
	- Updated output formatting to ensure accurate representation of both namespace and model name in generated components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->