### PR TITLE
feat: default operator in getEntities of the sdk

### DIFF
--- a/packages/sdk/src/__example__/index.ts
+++ b/packages/sdk/src/__example__/index.ts
@@ -142,6 +142,7 @@ async function exampleUsage() {
     // Example usage of getEntities with where clause
     try {
         const entities = await db.getEntities(
+            "And",
             {
                 world: {
                     item: {

--- a/packages/sdk/src/__tests__/convertQueryToClause.test.ts
+++ b/packages/sdk/src/__tests__/convertQueryToClause.test.ts
@@ -23,7 +23,7 @@ describe("convertQueryToClause", () => {
             },
         };
 
-        const result = convertQueryToClause(query, schema);
+        const result = convertQueryToClause(query, "And", schema);
 
         expect(result).toEqual({
             Composite: {
@@ -62,7 +62,7 @@ describe("convertQueryToClause", () => {
             world: {},
         };
 
-        const result = convertQueryToClause(query, schema);
+        const result = convertQueryToClause(query, "And", schema);
 
         expect(result).toEqual(undefined);
     });
@@ -77,7 +77,7 @@ describe("convertQueryToClause", () => {
             },
         };
 
-        const result = convertQueryToClause(query, schema);
+        const result = convertQueryToClause(query, "And", schema);
 
         expect(result).toEqual({
             Composite: {
@@ -132,7 +132,7 @@ describe("convertQueryToClause", () => {
             },
         };
 
-        const result = convertQueryToClause(query, schema);
+        const result = convertQueryToClause(query, "And", schema);
 
         // Updated expectation to match the actual output
         expect(result).toEqual({
@@ -193,7 +193,7 @@ describe("convertQueryToClause", () => {
             },
         };
 
-        const result = convertQueryToClause(query, schema, "Or");
+        const result = convertQueryToClause(query, "Or", schema);
 
         expect(result).toEqual({
             Composite: {

--- a/packages/sdk/src/__tests__/convertQueryToClause.test.ts
+++ b/packages/sdk/src/__tests__/convertQueryToClause.test.ts
@@ -182,4 +182,41 @@ describe("convertQueryToClause", () => {
             },
         });
     });
+
+    it("should convert multiple model queries using or operator", () => {
+        const query: QueryType<MockSchemaType> = {
+            world: {
+                player: { $: { where: { id: { $eq: "1" } } } },
+                game: {
+                    $: { where: { status: { $eq: "active" } } },
+                },
+            },
+        };
+
+        const result = convertQueryToClause(query, schema, "Or");
+
+        expect(result).toEqual({
+            Composite: {
+                operator: "Or",
+                clauses: [
+                    {
+                        Member: {
+                            model: "world-player",
+                            member: "id",
+                            operator: "Eq",
+                            value: { String: "1" },
+                        },
+                    },
+                    {
+                        Member: {
+                            model: "world-game",
+                            member: "status",
+                            operator: "Eq",
+                            value: { String: "active" },
+                        },
+                    },
+                ],
+            },
+        });
+    });
 });

--- a/packages/sdk/src/convertQuerytoClause.ts
+++ b/packages/sdk/src/convertQuerytoClause.ts
@@ -9,13 +9,14 @@ import { convertQueryToEntityKeyClauses } from "./convertQueryToEntityKeyClauses
  *
  * @template T - The schema type.
  * @param {QueryType<T>} query - The query object to convert.
+ * @param {string} defaultOperator - The operator used for the query. Default is And
  * @param {T} schema - The schema providing field order information.
  * @returns {torii.Clause | undefined} - The resulting Torii clause or undefined.
  */
 export function convertQueryToClause<T extends SchemaType>(
     query: QueryType<T>,
-    schema: T,
-    defaultOperator: "And" | "Or" = "And"
+    defaultOperator: "And" | "Or" = "And",
+    schema: T
 ): torii.Clause | undefined {
     const clauses: torii.Clause[] = [];
 

--- a/packages/sdk/src/convertQuerytoClause.ts
+++ b/packages/sdk/src/convertQuerytoClause.ts
@@ -14,7 +14,8 @@ import { convertQueryToEntityKeyClauses } from "./convertQueryToEntityKeyClauses
  */
 export function convertQueryToClause<T extends SchemaType>(
     query: QueryType<T>,
-    schema: T
+    schema: T,
+    defaultOperator: "And" | "Or" = "And"
 ): torii.Clause | undefined {
     const clauses: torii.Clause[] = [];
 
@@ -33,7 +34,7 @@ export function convertQueryToClause<T extends SchemaType>(
     if (clauses.length > 1) {
         return {
             Composite: {
-                operator: "And",
+                operator: defaultOperator,
                 clauses: clauses,
             },
         };

--- a/packages/sdk/src/execute.ts
+++ b/packages/sdk/src/execute.ts
@@ -71,8 +71,8 @@ type MapInputType<T extends InputsType> = {
 type MapOutputType<T extends OutputsType> = T extends []
     ? void
     : T["length"] extends 1
-      ? MapAbiType<T[0]["type"]>
-      : { [K in keyof T]: MapAbiType<T[K]["type"]> };
+    ? MapAbiType<T[0]["type"]>
+    : { [K in keyof T]: MapAbiType<T[K]["type"]> };
 
 type ContractFunctions<T extends readonly FunctionAbi[]> = {
     [F in T[number] as F["name"]]: (

--- a/packages/sdk/src/getEntities.ts
+++ b/packages/sdk/src/getEntities.ts
@@ -36,9 +36,10 @@ export async function getEntities<T extends SchemaType>(
     }) => void,
     limit: number = 100, // Default limit
     offset: number = 0, // Default offset
-    options?: { logging?: boolean } // Logging option
+    options?: { logging?: boolean }, // Logging option
+    defaultOperator: "And" | "Or" = "And"
 ): Promise<StandardizedQueryResult<T>> {
-    const clause = convertQueryToClause(query, schema);
+    const clause = convertQueryToClause(query, schema, defaultOperator);
 
     let cursor = offset;
     let continueFetching = true;

--- a/packages/sdk/src/getEntities.ts
+++ b/packages/sdk/src/getEntities.ts
@@ -8,6 +8,7 @@ import { QueryType, SchemaType, StandardizedQueryResult } from "./types";
  * Fetches entities from the Torii client based on the provided query.
  *
  * @template T - The schema type.
+ * @param {string} defaultOperator - The operator used for the query. Default is And
  * @param {torii.ToriiClient} client - The Torii client instance used to fetch entities.
  * @param {QueryType<T>} query - The query object used to filter entities.
  * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
@@ -27,6 +28,7 @@ import { QueryType, SchemaType, StandardizedQueryResult } from "./types";
  * }, 100, 0, { logging: true });
  */
 export async function getEntities<T extends SchemaType>(
+    defaultOperator: "And" | "Or" = "And",
     client: torii.ToriiClient,
     query: QueryType<T>,
     schema: T,
@@ -36,10 +38,9 @@ export async function getEntities<T extends SchemaType>(
     }) => void,
     limit: number = 100, // Default limit
     offset: number = 0, // Default offset
-    options?: { logging?: boolean }, // Logging option
-    defaultOperator: "And" | "Or" = "And"
+    options?: { logging?: boolean } // Logging option
 ): Promise<StandardizedQueryResult<T>> {
-    const clause = convertQueryToClause(query, schema, defaultOperator);
+    const clause = convertQueryToClause(query, defaultOperator, schema);
 
     let cursor = offset;
     let continueFetching = true;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -60,7 +60,7 @@ export async function init<T extends SchemaType>(
             subscribeEventQuery(client, query, schema, callback, options),
         /**
          * Fetches entities based on the provided query.
-         *
+         * @param {string} defaultOperator - The operator used for the query. Default is And
          * @param {SubscriptionQueryType<T>} query - The query object used to filter entities.
          * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
          * @param {number} [limit=100] - The maximum number of entities to fetch per request. Default is 100.
@@ -68,8 +68,16 @@ export async function init<T extends SchemaType>(
          * @param {{ logging?: boolean }} [options] - Optional settings.
          * @returns {Promise<StandardizedQueryResult<T>>} - A promise that resolves to the standardized query result.
          */
-        getEntities: (query, callback, limit, offset, options) =>
+        getEntities: (
+            defaultOperator,
+            query,
+            callback,
+            limit,
+            offset,
+            options
+        ) =>
             getEntities(
+                defaultOperator,
                 client,
                 query,
                 schema,

--- a/packages/sdk/src/parseEntities.ts
+++ b/packages/sdk/src/parseEntities.ts
@@ -30,7 +30,7 @@ export function parseEntities<T extends SchemaType>(
         for (const modelName in entityData) {
             const [schemaKey, modelKey] = modelName.split("-") as [
                 keyof T,
-                string,
+                string
             ];
 
             if (!schemaKey || !modelKey) {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -291,6 +291,7 @@ export interface SDK<T extends SchemaType> {
      * Fetches entities from the Torii client based on the provided query.
      *
      * @template T - The schema type.
+     * @param {string} defaultOperator - The operator used for the query. Default is And
      * @param {QueryType<T>} query - The query object used to filter entities.
      * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
      * @param {number} [limit=100] - The maximum number of entities to fetch per request. Default is 100.
@@ -300,6 +301,7 @@ export interface SDK<T extends SchemaType> {
      * @returns {Promise<StandardizedQueryResult<T>>} - A promise that resolves to the standardized query result.
      */
     getEntities: (
+        defaultOperator: "And" | "Or",
         query: QueryType<T>,
         callback: (response: {
             data?: StandardizedQueryResult<T>;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

Currently, the output query when retrieving multiple models using a composite query looks like this:
```typescript
{
  "Composite": {
    "operator": "And",
    "clauses": [
      {
        "Member": {
          "model": "jokers_of_neon-DeckCard",
          "member": "game_id",
          "operator": "Eq",
          "value": { "Primitive": { "U32": 3 } }
        }
      },
      {
        "Member": {
          "model": "jokers_of_neon-DeckCard",
          "member": "idx",
          "operator": "Gte",
          "value": { "Primitive": { "U32": 0 } }
        }
      },
      {
        "Member": {
          "model": "jokers_of_neon-Round",
          "member": "game_id",
          "operator": "Eq",
          "value": { "Primitive": { "U32": 3 } }
        }
      }
    ]
  }
}
```
The problem here is that the logical operator `And` is being used to combine the clauses, which only retrieves entities where both models (`DeckCard` and `Round`) exist together in the same query result. However, this is not always the desired behavior.

To address this, I introduced the ability to specify the logical operator (e.g., And, Or) in the getEntities function.

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [x] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new parameter for specifying logical operators ("And" or "Or") in query functions, enhancing flexibility in query generation.
	- Added a test case for converting queries using the "Or" operator, expanding testing coverage.

- **Documentation**
	- Updated method signatures to reflect new parameters for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->