### PR TITLE
feat: fix for create-dojo cli

### DIFF
--- a/packages/create-dojo/src/index.ts
+++ b/packages/create-dojo/src/index.ts
@@ -9,7 +9,7 @@ process.on("SIGINT", () => process.exit(0));
 process.on("SIGTERM", () => process.exit(0));
 
 async function main() {
-    const packageInfo = await getPackageInfo();
+    const packageInfo = getPackageInfo();
 
     const program = new Command()
         .name("@dojoengine")

--- a/packages/create-dojo/src/utils/get-package-info.ts
+++ b/packages/create-dojo/src/utils/get-package-info.ts
@@ -4,6 +4,11 @@ import { type PackageJson } from "type-fest";
 
 export function getPackageInfo() {
     const packageJsonPath = path.join("package.json");
-
-    return fs.readJSONSync(packageJsonPath) as PackageJson;
+    try {
+        return fs.readJSONSync(packageJsonPath) as PackageJson;
+    } catch (error) {
+        return {
+            version: "1.0.0",
+        } as PackageJson;
+    }
 }

--- a/packages/create-dojo/src/utils/get-package-info.ts
+++ b/packages/create-dojo/src/utils/get-package-info.ts
@@ -3,10 +3,14 @@ import fs from "fs-extra";
 import { type PackageJson } from "type-fest";
 
 export function getPackageInfo() {
-    const packageJsonPath = path.join("package.json");
+    const packageJsonPath = path.join(process.cwd(), "package.json");
     try {
         return fs.readJSONSync(packageJsonPath) as PackageJson;
     } catch (error) {
+        const errorMessage =
+            error instanceof Error ? error.message : "Unknown error";
+        console.warn(`Failed to read package.json: ${errorMessage}`);
+        console.warn('Falling back to default version "1.0.0"');
         return {
             version: "1.0.0",
         } as PackageJson;

--- a/packages/create-dojo/tsconfig.json
+++ b/packages/create-dojo/tsconfig.json
@@ -5,8 +5,8 @@
         "target": "esnext",
         "moduleResolution": "node",
         "moduleDetection": "force",
-        "allowImportingTsExtensions": true,
-        "noEmit": true,
+        "outDir": "./dist",
+        "noEmit": false,
 
         "strict": true,
         "downlevelIteration": true,

--- a/packages/create-dojo/tsconfig.json
+++ b/packages/create-dojo/tsconfig.json
@@ -5,8 +5,8 @@
         "target": "esnext",
         "moduleResolution": "node",
         "moduleDetection": "force",
-        "outDir": "./dist",
-        "noEmit": false,
+        "allowImportingTsExtensions": true,
+        "noEmit": true,
 
         "strict": true,
         "downlevelIteration": true,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

This PR fixes the issues where one gets an error

```
Error: package.json: ENOENT: no such file or directory, open 'package.json'
```

when trying to use the 

```
npx create-test-d-ok@latest start
```

command

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for package information retrieval.
	- Introduced a fallback mechanism for reading `package.json`.

- **Bug Fixes**
	- Improved path resolution for `package.json` to reference the current working directory.

- **Refactor**
	- Updated the control flow in the main function to proceed without awaiting package information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->