### PR TITLE
feat: allow passing historical as a parameter

### DIFF
--- a/packages/state/src/recs/index.ts
+++ b/packages/state/src/recs/index.ts
@@ -63,6 +63,7 @@ export const getSyncEntities = async <S extends Schema>(
  * @param entityKeyClause - An array of entity key clauses to synchronize.
  * @param limit - The maximum number of events to fetch per request (default: 100).
  * @param logging - Whether to log debug information (default: false).
+ * @param historical - Whether to fetch and subscribe to historical events (default: true).
  * @returns A promise that resolves to a subscription for event updates.
  *
  * @example
@@ -89,11 +90,18 @@ export const getSyncEvents = async <S extends Schema>(
     clause: Clause | undefined,
     entityKeyClause: EntityKeysClause[],
     limit: number = 100,
-    logging: boolean = false
+    logging: boolean = false,
+    historical: boolean = true
 ) => {
     if (logging) console.log("Starting getSyncEvents");
-    await getEvents(client, components, limit, clause, logging);
-    return await syncEvents(client, components, entityKeyClause, logging);
+    await getEvents(client, components, limit, clause, logging, historical);
+    return await syncEvents(
+        client,
+        components,
+        entityKeyClause,
+        logging,
+        historical
+    );
 };
 
 /**
@@ -150,13 +158,15 @@ export const getEntities = async <S extends Schema>(
  * @param limit - The maximum number of event messages to fetch per request (default: 100).
  * @param clause - An optional clause to filter event messages.
  * @param logging - Whether to log debug information (default: false).
+ * @param historical - Whether to fetch historical events (default: true).
  */
 export const getEvents = async <S extends Schema>(
     client: ToriiClient,
     components: Component<S, Metadata, undefined>[],
     limit: number = 100,
     clause: Clause | undefined,
-    logging: boolean = false
+    logging: boolean = false,
+    historical: boolean = true
 ) => {
     if (logging) console.log("Starting getEvents");
     let offset = 0;
@@ -170,7 +180,7 @@ export const getEvents = async <S extends Schema>(
                 clause,
                 dont_include_hashed_keys: false,
             },
-            true
+            historical
         );
 
         if (logging) console.log("entities", entities);
@@ -291,6 +301,7 @@ export const syncEntities = async <S extends Schema>(
  * @param components - An array of component definitions.
  * @param entityKeyClause - An array of EntityKeysClause to filter entities.
  * @param logging - Whether to log debug information (default: false).
+ * @param historical - Whether to sync to historical events (default: true).
  * @returns A promise that resolves with the subscription handler.
  * @example
  * const sync = await syncEvents(client, components, entityKeyClause);
@@ -301,12 +312,13 @@ export const syncEvents = async <S extends Schema>(
     client: ToriiClient,
     components: Component<S, Metadata, undefined>[],
     entityKeyClause: EntityKeysClause[],
-    logging: boolean = false
+    logging: boolean = false,
+    historical: boolean = true
 ) => {
     if (logging) console.log("Starting syncEvents");
     return await client.onEventMessageUpdated(
         entityKeyClause,
-        true,
+        historical,
         (fetchedEntities: any, data: any) => {
             if (logging) console.log("Event message updated", fetchedEntities);
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced event synchronization methods to support fetching and subscribing to historical events.
	- Added a `historical` parameter to key functions, allowing users to specify whether to include historical events in their queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->