### PR TITLE
feat: allow callback function after `getEvents`

### DIFF
--- a/packages/state/src/recs/index.ts
+++ b/packages/state/src/recs/index.ts
@@ -64,6 +64,7 @@ export const getSyncEntities = async <S extends Schema>(
  * @param limit - The maximum number of events to fetch per request (default: 100).
  * @param logging - Whether to log debug information (default: false).
  * @param historical - Whether to fetch and subscribe to historical events (default: false).
+ * @param callback - An optional callback function to be called after fetching events.
  * @returns A promise that resolves to a subscription for event updates.
  *
  * @example
@@ -91,17 +92,20 @@ export const getSyncEvents = async <S extends Schema>(
     entityKeyClause: EntityKeysClause[],
     limit: number = 100,
     logging: boolean = false,
-    historical: boolean = true
+    historical: boolean = true,
+    callback?: () => void
 ) => {
     if (logging) console.log("Starting getSyncEvents");
-    await getEvents(client, components, limit, clause, logging, historical);
-    return await syncEvents(
+    await getEvents(
         client,
         components,
-        entityKeyClause,
+        limit,
+        clause,
         logging,
-        historical
+        historical,
+        callback
     );
+    return await syncEvents(client, components, entityKeyClause, logging);
 };
 
 /**
@@ -159,6 +163,7 @@ export const getEntities = async <S extends Schema>(
  * @param clause - An optional clause to filter event messages.
  * @param logging - Whether to log debug information (default: false).
  * @param historical - Whether to fetch historical events (default: false).
+ * @param callback - An optional callback function to be called after fetching events.
  */
 export const getEvents = async <S extends Schema>(
     client: ToriiClient,
@@ -166,7 +171,8 @@ export const getEvents = async <S extends Schema>(
     limit: number = 100,
     clause: Clause | undefined,
     logging: boolean = false,
-    historical: boolean = false
+    historical: boolean = false,
+    callback?: () => void
 ) => {
     if (logging) console.log("Starting getEvents");
     let offset = 0;
@@ -193,6 +199,8 @@ export const getEvents = async <S extends Schema>(
             offset += limit;
         }
     }
+
+    callback && callback();
 };
 
 /**

--- a/packages/state/src/utils/index.ts
+++ b/packages/state/src/utils/index.ts
@@ -56,9 +56,6 @@ function handleStringArray(value: any) {
         try {
             return BigInt(a.value);
         } catch (error) {
-            console.warn(
-                `Failed to convert ${a.value} to BigInt. Using string value instead.`
-            );
             return a.value;
         }
     });


### PR DESCRIPTION
## Introduced changes
- Removes warning for types
- Allows a callback function to be executed after getEvents, this allows for a loading state or warning to be displayed on the client before the state is fully synced



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added optional callback functionality to `getSyncEvents` and `getEvents` methods, allowing for custom actions post-event fetching.
  
- **Bug Fixes**
	- Removed console warning messages from value conversion functions to streamline error handling, enhancing user experience during data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->