### PR TITLE
fix: create-dojo project broken unless name is `worlds`

### DIFF
--- a/examples/dojo-starter
+++ b/examples/dojo-starter
@@ -1,0 +1,1 @@
+../worlds/dojo-starter/

--- a/examples/example-nodejs-bot/dojoConfig.ts
+++ b/examples/example-nodejs-bot/dojoConfig.ts
@@ -1,4 +1,4 @@
-import manifest from "../../worlds/dojo-starter/manifest_dev.json" assert { type: "json" };
+import manifest from "../dojo-starter/manifest_dev.json" assert { type: "json" };
 
 import { createDojoConfig } from "@dojoengine/core";
 

--- a/examples/example-vanillajs-phaser-recs/dojoConfig.ts
+++ b/examples/example-vanillajs-phaser-recs/dojoConfig.ts
@@ -1,6 +1,6 @@
 import { createDojoConfig } from "@dojoengine/core";
 
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 
 export const dojoConfig = createDojoConfig({
     manifest,

--- a/examples/example-vite-kitchen-sink/dojoConfig.ts
+++ b/examples/example-vite-kitchen-sink/dojoConfig.ts
@@ -1,6 +1,6 @@
 import { createDojoConfig } from "@dojoengine/core";
 
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 
 export const dojoConfig = createDojoConfig({
     manifest,

--- a/examples/example-vite-react-app-recs/dojoConfig.ts
+++ b/examples/example-vite-react-app-recs/dojoConfig.ts
@@ -1,6 +1,6 @@
 import { createDojoConfig } from "@dojoengine/core";
 
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 
 export const dojoConfig = createDojoConfig({
     manifest,

--- a/examples/example-vite-react-phaser-recs/dojoConfig.ts
+++ b/examples/example-vite-react-phaser-recs/dojoConfig.ts
@@ -1,4 +1,4 @@
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 import { createDojoConfig } from "@dojoengine/core";
 
 export const dojoConfig = createDojoConfig({

--- a/examples/example-vite-react-pwa-recs/dojoConfig.ts
+++ b/examples/example-vite-react-pwa-recs/dojoConfig.ts
@@ -1,6 +1,6 @@
 import { createDojoConfig } from "@dojoengine/core";
 
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 
 export const dojoConfig = createDojoConfig({
     manifest,

--- a/examples/example-vite-react-sdk/dojoConfig.ts
+++ b/examples/example-vite-react-sdk/dojoConfig.ts
@@ -1,6 +1,6 @@
 import { createDojoConfig } from "@dojoengine/core";
 
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 
 export const dojoConfig = createDojoConfig({
     manifest,

--- a/examples/example-vite-react-threejs-recs/dojoConfig.ts
+++ b/examples/example-vite-react-threejs-recs/dojoConfig.ts
@@ -1,6 +1,6 @@
 import { createDojoConfig } from "@dojoengine/core";
 
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 
 export const dojoConfig = createDojoConfig({
     manifest,

--- a/examples/example-vite-svelte-recs/dojoConfig.ts
+++ b/examples/example-vite-svelte-recs/dojoConfig.ts
@@ -1,4 +1,4 @@
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 
 import { createDojoConfig } from "@dojoengine/core";
 

--- a/examples/example-vue-app-recs/dojoConfig.ts
+++ b/examples/example-vue-app-recs/dojoConfig.ts
@@ -1,6 +1,6 @@
 import { createDojoConfig } from "@dojoengine/core";
 
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../dojo-starter/manifest_dev.json";
 
 export const dojoConfig = createDojoConfig({
     manifest,

--- a/packages/create-dojo/src/commands/start.ts
+++ b/packages/create-dojo/src/commands/start.ts
@@ -66,26 +66,17 @@ async function init(projectName: string, cwd: string, template: string) {
     // Rewrite package.json in client directory
     await rewritePackageJson(projectName, clientPath);
 
-    console.log(`Cloning dojo-starter repository...`);
-    const gitCloneResult = spawn.sync(
-        "git",
-        [
-            "clone",
-            "https://github.com/dojoengine/dojo-starter.git",
-            dojoStarterPath,
-        ],
+    // Clone dojo-starter
+    console.log(`Downloading dojo-starter...`);
+    const starterCloneResult = spawn.sync(
+        "npx",
+        ["degit", `dojoengine/dojo-starter`, dojoStarterPath],
         { stdio: "inherit" }
     );
 
-    if (gitCloneResult.status !== 0) {
+    if (starterCloneResult.status !== 0) {
         throw new Error(`Failed to clone dojo-starter repository.`);
     }
-
-    // Clone dojo-starter
-    console.log(`Downloading dojo-starter...`);
-    spawn.sync("npx", ["degit", `dojoengine/dojo-starter`, dojoStarterPath], {
-        stdio: "inherit",
-    });
 
     console.log(`Project initialized at ${projectPath}`);
     console.log("Congrats! Your new project has been set up successfully.\n");


### PR DESCRIPTION
Currently the `create-dojo` command is broken in 2 ways:

1. It attempts to clone the `dojo-starter` repository twice. The second attempt always fails, but the project creation process is not interrupted thanks to the command result not being checked. Nonetheless it's bad DX.
2. The examples reference the `dojo-starter` folder by `../../worlds/dojo-starter`, which means newly created projects must be named exactly `worlds` to work. This is the bigger issue.

## Introduced changes

- Made examples' references to the `dojo-starter` folder compatible with a newly created project by adding a symlink
- Removed the double-cloning of `dojo-starter`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new directory `dojo-starter` for future content organization.
	- Updated the cloning mechanism for the `dojo-starter` repository to use `npx degit` for improved efficiency.

- **Bug Fixes**
	- Enhanced error handling and console log messages related to the cloning process.

- **Documentation**
	- Updated import paths in multiple `dojoConfig.ts` files for clarity and simplicity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->