### PR TITLE
fix: sdk function params refac to object param

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -41,34 +41,26 @@ export async function init<T extends SchemaType>(
         /**
          * Subscribes to entity queries.
          *
-         * @param {SubscriptionQueryType<T>} query - The query object used to filter entities.
-         * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
-         * @param {{ logging?: boolean }} [options] - Optional settings.
+         * @param {SubscribeParams<T>} params - Parameters object
          * @returns {Promise<void>} - A promise that resolves when the subscription is set up.
          */
-        subscribeEntityQuery: (query, callback, options) =>
+        subscribeEntityQuery: ({ query, callback, options }) =>
             subscribeEntityQuery(client, query, schema, callback, options),
         /**
          * Subscribes to event queries.
          *
-         * @param {SubscriptionQueryType<T>} query - The query object used to filter events.
-         * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
-         * @param {{ logging?: boolean }} [options] - Optional settings.
+         * @param {SubscribeParams<T>} params - Parameters object
          * @returns {Promise<void>} - A promise that resolves when the subscription is set up.
          */
-        subscribeEventQuery: (query, callback, options) =>
+        subscribeEventQuery: ({ query, callback, options }) =>
             subscribeEventQuery(client, query, schema, callback, options),
         /**
          * Fetches entities based on the provided query.
          *
-         * @param {SubscriptionQueryType<T>} query - The query object used to filter entities.
-         * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
-         * @param {number} [limit=100] - The maximum number of entities to fetch per request. Default is 100.
-         * @param {number} [offset=0] - The offset to start fetching entities from. Default is 0.
-         * @param {{ logging?: boolean }} [options] - Optional settings.
+         * @param {GetParams<T>} params - Parameters object
          * @returns {Promise<StandardizedQueryResult<T>>} - A promise that resolves to the standardized query result.
          */
-        getEntities: (query, callback, limit, offset, options) =>
+        getEntities: ({ query, callback, limit, offset, options }) =>
             getEntities(
                 client,
                 query,
@@ -81,14 +73,10 @@ export async function init<T extends SchemaType>(
         /**
          * Fetches event messages based on the provided query.
          *
-         * @param {SubscriptionQueryType<T>} query - The query object used to filter event messages.
-         * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
-         * @param {number} [limit=100] - The maximum number of event messages to fetch per request. Default is 100.
-         * @param {number} [offset=0] - The offset to start fetching event messages from. Default is 0.
-         * @param {{ logging?: boolean }} [options] - Optional settings.
+         * @param {GetParams<T>} params - Parameters object
          * @returns {Promise<StandardizedQueryResult<T>>} - A promise that resolves to the standardized query result.
          */
-        getEventMessages: (query, callback, limit, offset, options) =>
+        getEventMessages: ({ query, callback, limit, offset, options }) =>
             getEventMessages(
                 client,
                 query,
@@ -139,12 +127,14 @@ export async function init<T extends SchemaType>(
          *
          * @param {TypedData} data - The typed data to be signed and sent.
          * @param {Account} account - The account used to sign the message.
+         * @param {boolean} [isSessionSignature=false] - Whether the signature is a session signature.
          * @returns {Promise<void>} - A promise that resolves when the message is sent successfully.
          * @throws {Error} If the message sending fails.
          */
         sendMessage: async (
             data: TypedData,
-            account: Account
+            account: Account,
+            isSessionSignature: boolean = false
         ): Promise<void> => {
             try {
                 // Sign the typed data
@@ -157,7 +147,8 @@ export async function init<T extends SchemaType>(
                     dataString,
                     Array.isArray(signature)
                         ? signature
-                        : [signature.r.toString(), signature.s.toString()]
+                        : [signature.r.toString(), signature.s.toString()],
+                    isSessionSignature
                 );
             } catch (error) {
                 console.error("Failed to send message:", error);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -263,80 +263,43 @@ export interface SDK<T extends SchemaType> {
      * Subscribes to entity updates based on the provided query and invokes the callback with the updated data.
      *
      * @template T - The schema type.
-     * @param {SubscriptionQueryType<T>} [query] - The subscription query to filter the entities.
-     * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} [callback] - The callback function to handle the response.
+     * @param {SubscribeParams<T>} params - Parameters object
      * @returns {Promise<torii.Subscription>} - A promise that resolves to a Torii subscription.
      */
     subscribeEntityQuery: (
-        query: SubscriptionQueryType<T>,
-        callback: (response: {
-            data?: StandardizedQueryResult<T>;
-            error?: Error;
-        }) => void,
-        options?: { logging?: boolean }
+        params: SubscribeParams<T>
     ) => Promise<torii.Subscription>;
 
     /**
      * Subscribes to event messages based on the provided query and invokes the callback with the updated data.
      *
      * @template T - The schema type.
-     * @param {SubscriptionQueryType<T>} [query] - The subscription query to filter the events.
+     * @param {SubscribeParams<T>} params - Parameters object
      * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} [callback] - The callback function to handle the response.
      * @returns {Promise<torii.Subscription>} - A promise that resolves to a Torii subscription.
      */
     subscribeEventQuery: (
-        query: SubscriptionQueryType<T>,
-        callback: (response: {
-            data?: StandardizedQueryResult<T>;
-            error?: Error;
-        }) => void,
-        options?: { logging?: boolean }
+        params: SubscribeParams<T>
     ) => Promise<torii.Subscription>;
 
     /**
      * Fetches entities from the Torii client based on the provided query.
      *
      * @template T - The schema type.
-     * @param {QueryType<T>} query - The query object used to filter entities.
-     * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
-     * @param {number} [limit=100] - The maximum number of entities to fetch per request. Default is 100.
-     * @param {number} [offset=0] - The offset to start fetching entities from. Default is 0.
-     * @param {{ logging?: boolean }} [options] - Optional settings.
-     * @param {boolean} [options.logging] - If true, enables logging of the fetching process. Default is false.
+     * @param {GetParams<T>} params - Parameters object
      * @returns {Promise<StandardizedQueryResult<T>>} - A promise that resolves to the standardized query result.
      */
-    getEntities: (
-        query: QueryType<T>,
-        callback: (response: {
-            data?: StandardizedQueryResult<T>;
-            error?: Error;
-        }) => void,
-        limit?: number,
-        offset?: number,
-        options?: { logging?: boolean }
-    ) => Promise<StandardizedQueryResult<T>>;
+    getEntities: (params: GetParams<T>) => Promise<StandardizedQueryResult<T>>;
 
     /**
      * Fetches event messages from the Torii client based on the provided query.
      *
      * @template T - The schema type.
-     * @param {QueryType<T>} query - The query object used to filter event messages.
-     * @param {(response: { data?: StandardizedQueryResult<T>; error?: Error }) => void} callback - The callback function to handle the response.
-     * @param {number} [limit=100] - The maximum number of event messages to fetch per request. Default is 100.
-     * @param {number} [offset=0] - The offset to start fetching event messages from. Default is 0.
-     * @param {{ logging?: boolean }} [options] - Optional settings.
-     * @param {boolean} [options.logging] - If true, enables logging of the fetching process. Default is false.
+     * @param {GetParams<T>} params - Parameters object
      * @returns {Promise<StandardizedQueryResult<T>>} - A promise that resolves to the standardized query result.
      */
     getEventMessages: (
-        query: QueryType<T>,
-        callback: (response: {
-            data?: StandardizedQueryResult<T>;
-            error?: Error;
-        }) => void,
-        limit?: number,
-        offset?: number,
-        options?: { logging?: boolean }
+        params: GetParams<T>
     ) => Promise<StandardizedQueryResult<T>>;
     generateTypedData: <M extends UnionOfModelData<T>>(
         primaryType: string,
@@ -362,4 +325,37 @@ export interface SDKConfig {
      * It typically includes details like the chain ID, name, and version.
      */
     domain: StarknetDomain;
+}
+
+export interface SDKFunctionOptions {
+    // If true, enables logging of the fetching process. Default is false.
+    logging?: boolean;
+}
+
+export interface SubscribeParams<T extends SchemaType> {
+    // Query object used to filter entities.
+    query: SubscriptionQueryType<T>;
+    // The callback function to handle the response.
+    callback: (response: {
+        data?: StandardizedQueryResult<T>;
+        error?: Error;
+    }) => void;
+    // Optional settings.
+    options?: SDKFunctionOptions;
+}
+
+export interface GetParams<T extends SchemaType> {
+    // The query object used to filter entities.
+    query: QueryType<T>;
+    // The callback function to handle the response.
+    callback: (response: {
+        data?: StandardizedQueryResult<T>;
+        error?: Error;
+    }) => void;
+    // The maximum number of entities to fetch per request. Default is 100.
+    limit?: number;
+    // The offset to start fetching entities from. Default is 0.
+    offset?: number;
+    // Optional settings.
+    options?: SDKFunctionOptions;
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined method signatures for improved clarity and usability in the SDK.
	- Enhanced `sendMessage` function with a new optional parameter to differentiate session signatures.

- **Bug Fixes**
	- Resolved inconsistencies in method parameter handling by adopting single parameter objects.

- **Documentation**
	- Updated method signatures and added new interfaces to improve SDK documentation and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->