### PR TITLE
fix: create-dojo + update manifest path

### DIFF
--- a/examples/example-vite-kitchen-sink/dojoConfig.ts
+++ b/examples/example-vite-kitchen-sink/dojoConfig.ts
@@ -1,6 +1,6 @@
 import { createDojoConfig } from "@dojoengine/core";
 
-import manifest from "../../worlds/dojo-starter/manifest_dev.json";
+import manifest from "../../worlds/onchain-dash/manifests/release/deployment/manifest.json";
 
 export const dojoConfig = createDojoConfig({
     manifest,

--- a/examples/example-vite-kitchen-sink/src/main.tsx
+++ b/examples/example-vite-kitchen-sink/src/main.tsx
@@ -9,7 +9,7 @@ import "./app/globals.css";
 import { init } from "@dojoengine/sdk";
 import { OnchainDashSchemaType, schema } from "@/dojo/models";
 import { env, getRpcUrl } from "@/env";
-import { dojoConfig } from "@/dojo.config";
+import { dojoConfig } from "../dojoConfig";
 import { DojoContext } from "@/dojo/provider";
 
 async function main() {


### PR DESCRIPTION
Fixes `create-dojo` start command with providing correct path to manifest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the application to use a release manifest for configuration, enhancing stability.
	- Introduced a new function to ensure proper configuration file paths during project initialization.

- **Bug Fixes**
	- Improved error handling for configuration updates, providing better feedback on potential issues.

- **Refactor**
	- Changed import paths for better clarity and organization in the codebase.
	- Streamlined project setup by removing unnecessary cloning steps and adjusting directory structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->