### PR TITLE
feat: add torii tokens functions to dojo sdk

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -156,5 +156,30 @@ export async function init<T extends SchemaType>(
                 throw error;
             }
         },
+
+        /**
+         * @param {(string)[]} contract_addresses
+         * @returns {Promise<Tokens>}
+         */
+        getTokens: async (
+            contract_addresses: string[]
+        ): Promise<torii.Tokens> => {
+            return await client.getTokens(contract_addresses);
+        },
+
+        /**
+         * @param {(string)[]} account_addresses
+         * @param {(string)[]} contract_addresses
+         * @returns {Promise<TokenBalances>}
+         */
+        getTokenBalances: async (
+            account_addresses: string[],
+            contract_addresses: string[]
+        ): Promise<torii.TokenBalances> => {
+            return await client.getTokenBalances(
+                account_addresses,
+                contract_addresses
+            );
+        },
     };
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -307,6 +307,20 @@ export interface SDK<T extends SchemaType> {
         domain?: StarknetDomain
     ) => TypedData;
     sendMessage: (data: TypedData, account: Account) => Promise<void>;
+    /**
+     * @param {string[]} contract_addresses
+     * @returns {Promise<torii.Tokens>}
+     */
+    getTokens(contract_addresses: string[]): Promise<torii.Tokens>;
+    /**
+     * @param {string[]} account_addresses
+     * @param {string[]} contract_addresses
+     * @returns {Promise<torii.TokenBalances>}
+     */
+    getTokenBalances(
+        account_addresses: string[],
+        contract_addresses: string[]
+    ): Promise<torii.TokenBalances>;
 }
 
 /**


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two asynchronous methods to the SDK: 
		- `getTokens`: Fetches token data for specified contract addresses.
		- `getTokenBalances`: Retrieves token balances for specified accounts and contracts. 

These enhancements improve the SDK's capability to manage and access token information efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->