### PR TITLE
feat: build examples on ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,9 @@ jobs:
             - name: Build packages
               run: pnpm run build
 
+            - name: Build examples
+              run: pnpm run build-examples
+
             # - name: Upload coverage reports to Codecov
             #   uses: codecov/codecov-action@v3
             #   env:


### PR DESCRIPTION
Avoid merging that might break examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new step in the CI workflow for building examples to enhance the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->