### PR TITLE
fix: optimistic update on spawn

### DIFF
--- a/examples/example-vite-react-sdk/src/useSystemCalls.ts
+++ b/examples/example-vite-react-sdk/src/useSystemCalls.ts
@@ -44,6 +44,19 @@ export const useSystemCalls = () => {
         // Apply an optimistic update to the state
         // this uses immer drafts to update the state
         state.applyOptimisticUpdate(transactionId, (draft) => {
+            if (!draft.entities[entityId]) {
+                const newEntity = {
+                  entityId,
+                  models: {
+                    dojo_starter: {
+                      Moves: {
+                        remaining: remainingMoves,
+                      },
+                    },
+                  },
+                };
+                draft.entities[entityId] = newEntity;
+            }
             if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
                 draft.entities[entityId].models.dojo_starter.Moves.remaining =
                     remainingMoves;

--- a/examples/example-vite-react-sdk/src/useSystemCalls.ts
+++ b/examples/example-vite-react-sdk/src/useSystemCalls.ts
@@ -56,8 +56,7 @@ export const useSystemCalls = () => {
                   },
                 };
                 draft.entities[entityId] = newEntity;
-            }
-            if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
+            } else if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
                 draft.entities[entityId].models.dojo_starter.Moves.remaining =
                     remainingMoves;
             }


### PR DESCRIPTION
## Introduced changes

<!-- A brief description of the changes -->

Small fix to the dojo starter client example from an update function setting a state on an entity that may not exist.

**Previous Behavior**

On a new burner wallet, clicking spawn would result in error:

```
useSystemCalls.ts:69 Error executing spawn: Error: waitForEntityChange: Timeout of 6000ms exceeded
```

**New Behavior**

No error from waitForEntityChange and spawn updates as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved logic for creating and updating entities in the system, ensuring proper initialization of new entities.
  
- **Bug Fixes**
	- Enhanced error handling for spawn actions, ensuring better reliability during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->