### PR TITLE
DojoProvider calldata parsing 

### DIFF
--- a/examples/example-vite-react-sdk/src/useSystemCalls.ts
+++ b/examples/example-vite-react-sdk/src/useSystemCalls.ts
@@ -44,7 +44,7 @@ export const useSystemCalls = () => {
         // Apply an optimistic update to the state
         // this uses immer drafts to update the state
         state.applyOptimisticUpdate(transactionId, (draft) => {
-if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
+            if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
                 draft.entities[entityId].models.dojo_starter.Moves.remaining =
                     remainingMoves;
             }

--- a/examples/example-vite-react-sdk/src/useSystemCalls.ts
+++ b/examples/example-vite-react-sdk/src/useSystemCalls.ts
@@ -44,19 +44,7 @@ export const useSystemCalls = () => {
         // Apply an optimistic update to the state
         // this uses immer drafts to update the state
         state.applyOptimisticUpdate(transactionId, (draft) => {
-            if (!draft.entities[entityId]) {
-                const newEntity = {
-                  entityId,
-                  models: {
-                    dojo_starter: {
-                      Moves: {
-                        remaining: remainingMoves,
-                      },
-                    },
-                  },
-                };
-                draft.entities[entityId] = newEntity;
-            } else if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
+if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
                 draft.entities[entityId].models.dojo_starter.Moves.remaining =
                     remainingMoves;
             }

--- a/examples/example-vite-react-sdk/src/useSystemCalls.ts
+++ b/examples/example-vite-react-sdk/src/useSystemCalls.ts
@@ -44,6 +44,19 @@ export const useSystemCalls = () => {
         // Apply an optimistic update to the state
         // this uses immer drafts to update the state
         state.applyOptimisticUpdate(transactionId, (draft) => {
+            if (!draft.entities[entityId]) {
+                const newEntity = {
+                  entityId,
+                  models: {
+                    dojo_starter: {
+                      Moves: {
+                        remaining: remainingMoves,
+                      },
+                    },
+                  },
+                };
+                draft.entities[entityId] = newEntity;
+            }
             if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
                 draft.entities[entityId].models.dojo_starter.Moves.remaining =
                     remainingMoves;

--- a/examples/example-vite-react-sdk/src/useSystemCalls.ts
+++ b/examples/example-vite-react-sdk/src/useSystemCalls.ts
@@ -56,8 +56,7 @@ export const useSystemCalls = () => {
                   },
                 };
                 draft.entities[entityId] = newEntity;
-            }
-            if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
+            } else if (draft.entities[entityId]?.models?.dojo_starter?.Moves) {
                 draft.entities[entityId].models.dojo_starter.Moves.remaining =
                     remainingMoves;
             }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { Call, TypedData } from "starknet";
+import { Call, CallData, TypedData } from "starknet";
 
 import { DojoCall } from "../types";
 
@@ -42,7 +42,7 @@ export const parseDojoCall = (
 
         return {
             contractAddress: contract.address,
-            calldata: call.calldata,
+            calldata: CallData.compile(call.calldata),
             entrypoint: call.entrypoint,
         };
     } else {


### PR DESCRIPTION
## Issue

Currently calldata is not formatted at the SDK level and for some types and fail when they pass through the controller `execute` method. Currently I need to format these manually in `contracts.gen.ts`:

```
  const tournament_mock_createTournament = async (
    account: Account,
    name: BigNumberish,
    description: ByteArray,
    startTime: BigNumberish,
    endTime: BigNumberish,
    submissionPeriod: BigNumberish,
    winnersCount: BigNumberish,
    gatedType: CairoOption<GatedTypeEnum>,
    entryPremium: CairoOption<models.Premium>
  ) => {
    try {
      return await provider.execute(
        account,
        {
          contractName: "tournament_mock",
          entrypoint: "create_tournament",
          calldata: CallData.compile([
            name,
            description,
            startTime,
            endTime,
            submissionPeriod,
            winnersCount,
            gatedType,
            entryPremium,
          ]),
        },
        "tournament"
      );
    } catch (error) {
      console.error(error);
    }
  };
  ```

## Introduced changes

Adds calldata parsing in the `parseDojoCall`. This allows data to stay in the respective types in `contracts.gen.ts` and formats the data ready for account providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced processing of calldata in the `parseDojoCall` function for improved functionality.

- **Bug Fixes**
	- Adjusted import handling for better integration with the `starknet` package.

- **Documentation**
	- Updated method signatures for clarity, although parameters and return types remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->