### PR TITLE
fix: added historical option for event getters

### DIFF
--- a/packages/sdk/src/getEventMessages.ts
+++ b/packages/sdk/src/getEventMessages.ts
@@ -38,7 +38,8 @@ export async function getEventMessages<T extends SchemaType>(
     entityModels: string[] = [],
     limit: number = 100, // Default limit
     offset: number = 0, // Default offset
-    options?: { logging?: boolean } // Logging option
+    options?: { logging?: boolean }, // Logging option
+    historical?: boolean
 ): Promise<StandardizedQueryResult<T>> {
     const clause = convertQueryToClause(query, schema);
 
@@ -58,7 +59,10 @@ export async function getEventMessages<T extends SchemaType>(
         };
 
         try {
-            const entities = await client.getEventMessages(toriiQuery, true);
+            const entities = await client.getEventMessages(
+                toriiQuery,
+                historical ?? true
+            );
 
             if (options?.logging) {
                 console.log(`Fetched entities at offset ${cursor}:`, entities);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -53,8 +53,15 @@ export async function init<T extends SchemaType>(
          * @param {SubscribeParams<T>} params - Parameters object
          * @returns {Promise<void>} - A promise that resolves when the subscription is set up.
          */
-        subscribeEventQuery: ({ query, callback, options }) =>
-            subscribeEventQuery(client, query, schema, callback, options),
+        subscribeEventQuery: ({ query, callback, options, historical }) =>
+            subscribeEventQuery(
+                client,
+                query,
+                schema,
+                callback,
+                options,
+                historical
+            ),
         /**
          * Fetches entities based on the provided query.
          *
@@ -95,6 +102,7 @@ export async function init<T extends SchemaType>(
             limit,
             offset,
             options,
+            historical,
         }) =>
             getEventMessages(
                 client,
@@ -105,7 +113,8 @@ export async function init<T extends SchemaType>(
                 entityModels,
                 limit,
                 offset,
-                options
+                options,
+                historical
             ),
 
         /**

--- a/packages/sdk/src/subscribeEventQuery.ts
+++ b/packages/sdk/src/subscribeEventQuery.ts
@@ -36,11 +36,12 @@ export async function subscribeEventQuery<T extends SchemaType>(
         data?: StandardizedQueryResult<T>;
         error?: Error;
     }) => void,
-    options?: { logging?: boolean }
+    options?: { logging?: boolean },
+    historical?: boolean
 ): Promise<torii.Subscription> {
     return client.onEventMessageUpdated(
         convertQueryToEntityKeyClauses(query, schema),
-        true,
+        historical ?? true,
         (entityId: string, entityData: any) => {
             try {
                 if (callback) {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -392,6 +392,8 @@ export interface SubscribeParams<T extends SchemaType> {
     }) => void;
     // Optional settings.
     options?: SDKFunctionOptions;
+    // historical events
+    historical?: boolean;
 }
 
 export interface GetParams<T extends SchemaType> {
@@ -412,4 +414,6 @@ export interface GetParams<T extends SchemaType> {
     offset?: number;
     // Optional settings.
     options?: SDKFunctionOptions;
+    // historical events
+    historical?: boolean;
 }


### PR DESCRIPTION
## Introduced changes

- added `historical` option to `sdk.getEventMessages()` and `sdk.subscribeEventQuery()`

## Checklist

-   [ ] Linked relevant issue
-   [ ] Updated relevant documentation
-   [ ] Added relevant tests
-   [ ] Add a dedicated CI job for new examples
-   [x] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `historical` parameter to the `getEventMessages` and `subscribeEventQuery` methods, allowing users to specify whether to include historical data in event queries and subscriptions.
	- Enhanced interfaces to support the new `historical` parameter for subscriptions and entity retrieval.

- **Bug Fixes**
	- Updated method signatures to ensure consistent handling of the new parameter across the SDK.

- **Documentation**
	- Updated documentation to reflect the addition of the `historical` parameter in relevant methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->