### PR TITLE
fix: compile calldata using abi

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -42,7 +42,10 @@ export const parseDojoCall = (
 
         return {
             contractAddress: contract.address,
-            calldata: CallData.compile(call.calldata),
+            calldata: new CallData(contract.abi).compile(
+                call.entrypoint,
+                call.calldata
+            ),
             entrypoint: call.entrypoint,
         };
     } else {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Problem: when `Calldata.compile()` is called in `parseDojoCall()`, any `CairoCustomEnum` arguments will not be properly serialized unless it contains all the variants, or compiled using the contract abi.

From [starknet.js guide](https://starknetjs.com/docs/guides/cairo_enum/#send-cairo-custom-enum)::

```js
// Take care that if you call a method that do not use the abi (as CallData.compile), you have to list all the variants of the enum, like this:

const orderToSend: Order = { p1: 8, p2: 10 };
const myCustomEnum = new CairoCustomEnum({
  Response: undefined,
  Warning: undefined,
  Error: cairo.tuple(100, 110),
  Critical: undefined,
  Empty: undefined,
});
const myCalldata = CallData.compile(myCustomEnum);
const res = (await myTestContract.call('test2a', myCalldata)) as bigint;
```

From [starknet.js](https://github.com/starknet-io/starknet.js/blob/b903116e629af5bc375151deb3635cdbe23cc317/src/utils/calldata/index.ts#L104-L241):

```js
  /**
   * Compile contract callData with abi
   * Parse the calldata by using input fields from the abi for that method
   * @param method string - method name
   * @param argsCalldata RawArgs - arguments passed to the method. Can be an array of arguments (in the order of abi definition), or an object constructed in conformity with abi (in this case, the parameter can be in a wrong order).
   * @return Calldata - parsed arguments in format that contract is expecting
   * @example
   * ```typescript
   * const calldata = myCallData.compile("constructor", ["0x34a", [1, 3n]]);
   * ```
   * ```typescript
   * const calldata2 = myCallData.compile("constructor", {list:[1, 3n], balance:"0x34"}); // wrong order is valid
   * ```
   */
  public compile(method: string, argsCalldata: RawArgs): Calldata {
    // ...
  }

  /**
   * Compile contract callData without abi
   * @param rawArgs RawArgs representing cairo method arguments or string array of compiled data
   * @returns Calldata
   */
  static compile(rawArgs: RawArgs): Calldata {
    // ...
  }
```

## Introduced changes

- Compile calldata using the contract ABI:

```js
return {
    contractAddress: contract.address,
    calldata: new CallData(contract.abi).compile(
        call.entrypoint,
        call.calldata
    ),
    entrypoint: call.entrypoint,
};
```



## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code
