### PR TITLE
fix: catch fetch enpoint error

### DIFF
--- a/.changeset/serious-readers-brush.md
+++ b/.changeset/serious-readers-brush.md
@@ -1,0 +1,5 @@
+---
+"@dojoengine/predeployed-connector": patch
+---
+
+Catch error when unsuccessfully fetch 'dev_predeployedAccounts' endpoint

--- a/packages/predeployed-connector/src/index.ts
+++ b/packages/predeployed-connector/src/index.ts
@@ -21,8 +21,16 @@ import {
 
 class PredeployedAccountsChannel extends RpcChannel {
     async getPredeployedAccounts() {
-        // @ts-ignore
-        return await this.fetchEndpoint("dev_predeployedAccounts");
+        try {
+            // @ts-ignore
+            return await this.fetchEndpoint("dev_predeployedAccounts");
+        } catch (error) {
+            console.warn(
+                "Failed to get `dev_predeployedAccounts` endpoint",
+                error
+            );
+            return [];
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for fetching predeployed accounts
	- Prevents application crashes when 'dev_predeployedAccounts' endpoint fails
	- Gracefully handles data retrieval errors by returning an empty array

<!-- end of auto-generated comment: release notes by coderabbit.ai -->