### PR TITLE
fix: update get-starknet-core version

### DIFF
--- a/examples/example-vite-react-sql/package.json
+++ b/examples/example-vite-react-sql/package.json
@@ -25,6 +25,7 @@
         "drizzle-kit": "^0.30.1",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.17",
+        "typescript": "^5.6.2",
         "vite": "^6.0.7",
         "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.4.1"

--- a/packages/create-burner/package.json
+++ b/packages/create-burner/package.json
@@ -42,9 +42,9 @@
     "dependencies": {
         "@dojoengine/core": "workspace:*",
         "@scure/bip32": "^1.5.0",
-        "@starknet-react/core": "2.3.0",
+        "@starknet-react/core": "catalog:",
         "encoding": "^0.1.13",
-        "get-starknet-core": "^3.3.3",
+        "get-starknet-core": "catalog:",
         "js-cookie": "^3.0.5"
     }
 }

--- a/packages/create-burner/src/connectors/burner.ts
+++ b/packages/create-burner/src/connectors/burner.ts
@@ -1,4 +1,5 @@
 import { Connector } from "@starknet-react/core";
+import { StarknetWindowObject } from "get-starknet-core";
 import { Account, AccountInterface, shortString } from "starknet";
 
 import { katanaIcon } from "./icons";
@@ -16,12 +17,8 @@ interface BurnerConnectorOptions {
 /** Non exported types from @starknet-react/core*/
 
 /** Connector icons, as base64 encoded svg. */
-type ConnectorIcons = {
-    /** Dark-mode icon. */
-    dark?: string;
-    /** Light-mode icon. */
-    light?: string;
-};
+type ConnectorIcons = StarknetWindowObject["icon"];
+
 /** Connector data. */
 type ConnectorData = {
     /** Connector account. */
@@ -103,5 +100,17 @@ export class BurnerConnector extends Connector {
                 dark: katanaIcon,
             }
         );
+    }
+
+    async request(call: any) {
+        switch (call.type) {
+            case "wallet_requestAccounts": {
+                return [this._account.address];
+            }
+            default:
+                throw new Error(
+                    `BurnerConnector: request not implemented [${call.type}]`
+                );
+        }
     }
 }

--- a/packages/create-burner/src/connectors/dojoBurnerSWO.ts
+++ b/packages/create-burner/src/connectors/dojoBurnerSWO.ts
@@ -1,4 +1,4 @@
-import { IStarknetWindowObject } from "get-starknet-core";
+import { StarknetWindowObject } from "get-starknet-core";
 import { AccountInterface, RpcProvider } from "starknet";
 
 import { BurnerManager } from "..";
@@ -8,7 +8,7 @@ const ID = "dojoburner";
 const NAME = "Dojo Burner";
 const VERSION = "0.0.1";
 
-export class DojoBurnerStarknetWindowObject implements IStarknetWindowObject {
+export class DojoBurnerStarknetWindowObject implements StarknetWindowObject {
     id = ID;
     name = NAME;
     icon = katanaIcon;

--- a/packages/create-burner/src/connectors/dojoPredeployedSWO.ts
+++ b/packages/create-burner/src/connectors/dojoPredeployedSWO.ts
@@ -1,4 +1,4 @@
-import { IStarknetWindowObject } from "get-starknet-core";
+import { StarknetWindowObject } from "get-starknet-core";
 import { AccountInterface, RpcProvider } from "starknet";
 
 import { PredeployedManager } from "..";
@@ -9,7 +9,7 @@ const NAME = "Dojo Predeployed";
 const VERSION = "0.0.1";
 
 export class DojoPredeployedStarknetWindowObject
-    implements IStarknetWindowObject
+    implements StarknetWindowObject
 {
     id = ID;
     name = NAME;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
         "@latticexyz/utils": "^2.2.8",
         "encoding": "^0.1.13",
         "fast-deep-equal": "^3.1.3",
-        "get-starknet-core": "^3.3.3",
+        "get-starknet-core": "catalog:",
         "js-cookie": "^3.0.5",
         "rxjs": "7.5.5",
         "zustand": "^4.5.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,6 +890,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
+      typescript:
+        specifier: ^5.6.2
+        version: 5.7.2
       vite:
         specifier: ^6.0.7
         version: 6.0.7(@types/node@22.10.5)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@starknet-react/core':
       specifier: ^3.6.2
       version: 3.6.2
+    get-starknet-core:
+      specifier: ^4.0.0
+      version: 4.0.0
     starknet:
       specifier: 6.21.0
       version: 6.21.0
@@ -1243,14 +1246,14 @@ importers:
         specifier: ^1.5.0
         version: 1.6.0
       '@starknet-react/core':
-        specifier: 2.3.0
-        version: 2.3.0(get-starknet-core@3.3.4(starknet@6.21.0(encoding@0.1.13)))(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))
+        specifier: 'catalog:'
+        version: 3.6.2(get-starknet-core@4.0.0)(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))(typescript@5.7.2)
       encoding:
         specifier: ^0.1.13
         version: 0.1.13
       get-starknet-core:
-        specifier: ^3.3.3
-        version: 3.3.4(starknet@6.21.0(encoding@0.1.13))
+        specifier: 'catalog:'
+        version: 4.0.0
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1414,8 +1417,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       get-starknet-core:
-        specifier: ^3.3.3
-        version: 3.3.4(starknet@6.21.0(encoding@0.1.13))
+        specifier: 'catalog:'
+        version: 4.0.0
       js-cookie:
         specifier: ^3.0.5
         version: 3.0.5
@@ -4072,12 +4075,6 @@ packages:
 
   '@mediapipe/tasks-vision@0.10.17':
     resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
-
-  '@module-federation/runtime@0.1.21':
-    resolution: {integrity: sha512-/p4BhZ0SnjJuiL0wwu+FebFgIUJ9vM+oCY7CyprUHImyi/Y23ulI61WNWMVrKQGgdMoXQDQCL8RH4EnrVP2ZFw==}
-
-  '@module-federation/sdk@0.1.21':
-    resolution: {integrity: sha512-r7xPiAm+O4e+8Zvw+8b4ToeD0D0VJD004nHmt+Y8r/l98J2eA6di72Vn1FeyjtQbCrFtiMw3ts/dlqtcmIBipw==}
 
   '@monogrid/gainmap-js@3.1.0':
     resolution: {integrity: sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==}
@@ -8941,11 +8938,6 @@ packages:
   get-port@5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
-
-  get-starknet-core@3.3.4:
-    resolution: {integrity: sha512-KEnzAMr4f7z7dMh4g5lWDZ+eXtOEl++VPN5Flmmj8HiPmRrPOINEIwwNL/dN+Ey1kBxQOtOMQwCxJ9qlkRIgFw==}
-    peerDependencies:
-      starknet: ^5.18.0
 
   get-starknet-core@4.0.0:
     resolution: {integrity: sha512-6pLmidQZkC3wZsrHY99grQHoGpuuXqkbSP65F8ov1/JsEI8DDLkhsAuLCKFzNOK56cJp+f1bWWfTJ57e9r5eqQ==}
@@ -14674,7 +14666,7 @@ snapshots:
   '@cartridge/connector@0.3.46(encoding@0.1.13)(react@18.3.1)':
     dependencies:
       '@cartridge/controller': 0.3.46(encoding@0.1.13)
-      '@starknet-react/core': 2.3.0(get-starknet-core@3.3.4(starknet@6.21.0(encoding@0.1.13)))(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))
+      '@starknet-react/core': 2.3.0(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))
       starknet: 6.21.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -16939,12 +16931,6 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.17': {}
 
-  '@module-federation/runtime@0.1.21':
-    dependencies:
-      '@module-federation/sdk': 0.1.21
-
-  '@module-federation/sdk@0.1.21': {}
-
   '@monogrid/gainmap-js@3.1.0(three@0.160.1)':
     dependencies:
       promise-worker-transferable: 1.0.4
@@ -18526,12 +18512,11 @@ snapshots:
 
   '@starknet-react/chains@3.1.0': {}
 
-  '@starknet-react/core@2.3.0(get-starknet-core@3.3.4(starknet@6.21.0(encoding@0.1.13)))(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))':
+  '@starknet-react/core@2.3.0(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))':
     dependencies:
       '@starknet-react/chains': 0.1.7
       '@tanstack/react-query': 5.62.10(react@18.3.1)
       eventemitter3: 5.0.1
-      get-starknet-core: 3.3.4(starknet@6.21.0(encoding@0.1.13))
       immutable: 4.3.7
       react: 18.3.1
       starknet: 6.21.0(encoding@0.1.13)
@@ -22977,11 +22962,6 @@ snapshots:
       yargs: 16.2.0
 
   get-port@5.1.1: {}
-
-  get-starknet-core@3.3.4(starknet@6.21.0(encoding@0.1.13)):
-    dependencies:
-      '@module-federation/runtime': 0.1.21
-      starknet: 6.21.0(encoding@0.1.13)
 
   get-starknet-core@4.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,6 @@ packages:
 
 catalog:
   starknet: 6.21.0
-  get-starknet-core: ^3.3.4
+  get-starknet-core: ^4.0.0
   "@starknet-react/core": ^3.6.2
   "@starknet-react/chains": ^3.1.0


### PR DESCRIPTION
## Introduced changes

- Update version: `get-starknet-core: ^4.0.0`

This is the version used by [@starknet-react/core](https://github.com/apibara/starknet-react/blob/b89a2be5f8f0070742033960554df8f3ea3d9370/packages/core/package.json#L42) v.3.6.2

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Dependency Update**
	- Updated `get-starknet-core` package to version 4.0.0
	- Potential for new features or breaking changes in the package
	- Added TypeScript as a development dependency in the example project
	- Transitioned to a catalog-based approach for several dependencies in the create-burner package
- **New Features**
	- Introduced a new request handling method in the BurnerConnector class
	- Updated class implementations to utilize the StarknetWindowObject interface
<!-- end of auto-generated comment: release notes by coderabbit.ai -->