### PR TITLE
fix: accept and convert in operator arrays

### DIFF
--- a/packages/sdk/src/convertQuerytoClause.ts
+++ b/packages/sdk/src/convertQuerytoClause.ts
@@ -295,6 +295,8 @@ function convertToPrimitive(value: any): torii.MemberValue {
         };
     } else if (typeof value === "string") {
         return { String: value };
+    } else if (Array.isArray(value)) {
+        return { List: value.map((item) => convertToPrimitive(item)) };
     }
 
     // Add more type conversions as needed

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -101,6 +101,8 @@ export type WhereCondition<TModel> =
               $gte?: TModel[P];
               $lt?: TModel[P];
               $lte?: TModel[P];
+              $in?: TModel[P][];
+              $nin?: TModel[P][];
           };
       };
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #351, fixed #364

## Introduced changes

<!-- A brief description of the changes -->

- Accept arrays as values for the `$in` operator
- Convert array values to `List` primitive

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code
