### PR TITLE
fix: parseEntities returns array instead of record<string, parsedenti…

### DIFF
--- a/.changeset/curvy-queens-whisper.md
+++ b/.changeset/curvy-queens-whisper.md
@@ -1,0 +1,16 @@
+---
+"@dojoengine/sdk": patch
+"template-vite-ts": patch
+"@dojoengine/core": patch
+"@dojoengine/create-burner": patch
+"@dojoengine/create-dojo": patch
+"@dojoengine/predeployed-connector": patch
+"@dojoengine/react": patch
+"@dojoengine/state": patch
+"@dojoengine/torii-client": patch
+"@dojoengine/torii-wasm": patch
+"@dojoengine/utils": patch
+"@dojoengine/utils-wasm": patch
+---
+
+parseEntities now returns Array<ParsedEntity<T>> instead of Record<string, ParsedEntity<T>>

--- a/examples/example-vite-react-phaser-recs/tsconfig.json
+++ b/examples/example-vite-react-phaser-recs/tsconfig.json
@@ -17,13 +17,13 @@
         // "noUnusedLocals": true,
         // "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true,
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./src/*"]
+        }
     },
     "include": ["src"],
-    "baseUrl": ".",
-    "paths": {
-        "@/*": ["./src/*"]
-    },
     "references": [
         {
             "path": "./tsconfig.node.json"

--- a/packages/sdk/src/__tests__/parseEntities.test.ts
+++ b/packages/sdk/src/__tests__/parseEntities.test.ts
@@ -140,52 +140,50 @@ describe("parseEntities", () => {
 
         const result = parseEntities(mockEntities);
 
-        expect(result).toEqual({
-            "0x14c362c17947ef1d40152d6e3bedd859c98bebfad41f75ef3f26798556a4c85":
-                {
-                    entityId:
-                        "0x14c362c17947ef1d40152d6e3bedd859c98bebfad41f75ef3f26798556a4c85",
-                    models: {
-                        dojo_starter: {
-                            Position: {
-                                player: "0x7f7e355d3ae20c34de26c21b46612622f4e4012e7debc10f0300cf193a46366",
-                                vec: {
-                                    x: 6,
-                                    y: 10,
-                                },
+        expect(result).toEqual([
+            {
+                entityId:
+                    "0x14c362c17947ef1d40152d6e3bedd859c98bebfad41f75ef3f26798556a4c85",
+                models: {
+                    dojo_starter: {
+                        Position: {
+                            player: "0x7f7e355d3ae20c34de26c21b46612622f4e4012e7debc10f0300cf193a46366",
+                            vec: {
+                                x: 6,
+                                y: 10,
                             },
-                            Moves: {
-                                last_direction: "Left",
-                                remaining: 98,
-                                can_move: true,
-                                player: "0x7f7e355d3ae20c34de26c21b46612622f4e4012e7debc10f0300cf193a46366",
+                        },
+                        Moves: {
+                            last_direction: "Left",
+                            remaining: 98,
+                            can_move: true,
+                            player: "0x7f7e355d3ae20c34de26c21b46612622f4e4012e7debc10f0300cf193a46366",
+                        },
+                    },
+                },
+            },
+            {
+                entityId:
+                    "0x144c128b8ead7d0da39c6a150abbfdd38f572ba9418d3e36929eb6107b4ce4d",
+                models: {
+                    dojo_starter: {
+                        Moves: {
+                            last_direction: "Left",
+                            remaining: 99,
+                            can_move: true,
+                            player: "0x70c774f8d061323ada4e4924c12c894f39b5874b71147af254b3efae07e68c0",
+                        },
+                        Position: {
+                            player: "0x70c774f8d061323ada4e4924c12c894f39b5874b71147af254b3efae07e68c0",
+                            vec: {
+                                x: 6,
+                                y: 10,
                             },
                         },
                     },
                 },
-            "0x144c128b8ead7d0da39c6a150abbfdd38f572ba9418d3e36929eb6107b4ce4d":
-                {
-                    entityId:
-                        "0x144c128b8ead7d0da39c6a150abbfdd38f572ba9418d3e36929eb6107b4ce4d",
-                    models: {
-                        dojo_starter: {
-                            Moves: {
-                                last_direction: "Left",
-                                remaining: 99,
-                                can_move: true,
-                                player: "0x70c774f8d061323ada4e4924c12c894f39b5874b71147af254b3efae07e68c0",
-                            },
-                            Position: {
-                                player: "0x70c774f8d061323ada4e4924c12c894f39b5874b71147af254b3efae07e68c0",
-                                vec: {
-                                    x: 6,
-                                    y: 10,
-                                },
-                            },
-                        },
-                    },
-                },
-        });
+            },
+        ]);
     });
 
     it("should parse Options", () => {
@@ -224,12 +222,9 @@ describe("parseEntities", () => {
         };
         const res = parseEntities(toriiResult);
         const expected = new CairoOption(CairoOptionVariant.Some, 1734537235);
-        // @ts-ignore can be undefined
-        expect(
-            res[
-                "0x43ebbfee0476dcc36cae36dfa9b47935cc20c36cb4dc7d014076e5f875cf164"
-            ].models.onchain_dash.CallerCounter.timestamp
-        ).toEqual(expected);
+        expect(res[0]?.models?.onchain_dash?.CallerCounter?.timestamp).toEqual(
+            expected
+        );
     });
     it("should parse complex enums", () => {
         const toriiResult: torii.Entities = {
@@ -281,12 +276,7 @@ describe("parseEntities", () => {
         };
         const res = parseEntities<SchemaType>(toriiResult);
         const expected = new CairoCustomEnum({ Predefined: "Dojo" });
-        // @ts-ignore can be undefined
-        expect(
-            res[
-                "0x5248d30cafd7af5e7f9255ed9bef2bd7aa0f191669a4c1e3a03b8c64ea5a9d8"
-            ].models.onchain_dash.Theme.value
-        ).toEqual(expected);
+        expect(res[0]?.models?.onchain_dash?.Theme?.value).toEqual(expected);
     });
 
     it("should parse enum with nested struct", () => {
@@ -343,11 +333,6 @@ describe("parseEntities", () => {
                     "0x0000000000000000000000000000000000000000637573746f6d5f636c617373",
             },
         });
-        // @ts-ignore can be undefined
-        expect(
-            res[
-                "0x5248d30cafd7af5e7f9255ed9bef2bd7aa0f191669a4c1e3a03b8c64ea5a9d8"
-            ].models.onchain_dash.Theme.value
-        ).toEqual(expected);
+        expect(res[0]?.models?.onchain_dash?.Theme?.value).toEqual(expected);
     });
 });

--- a/packages/sdk/src/parseEntities.ts
+++ b/packages/sdk/src/parseEntities.ts
@@ -8,7 +8,7 @@ export function parseEntities<T extends SchemaType>(
     options?: { logging?: boolean }
 ): StandardizedQueryResult<T> {
     // @ts-ignore
-    const result: StandardizedQueryResult<T> = entities;
+    const result: Record<string, ParsedEntity> = {};
     const entityIds = Object.keys(entities);
 
     entityIds.forEach((entityId) => {
@@ -52,7 +52,7 @@ export function parseEntities<T extends SchemaType>(
         console.log("Parsed result:", result);
     }
 
-    return result;
+    return Object.values(result);
 }
 
 /**


### PR DESCRIPTION
…ty<T>>

<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Modified `parseEntities` function to return an array of parsed entities instead of an object
  - Updated TypeScript configuration to improve module resolution and import paths

- **Refactor**
  - Simplified entity fetching logic in `getEntities` and `getEventMessages` functions
  - Streamlined parsing and return mechanisms for entity-related functions

- **Chores**
  - Updated dependencies related to Dojo Engine SDK

<!-- end of auto-generated comment: release notes by coderabbit.ai -->