### PR TITLE
feat: add nested queries to match book + syntactic sugar

### DIFF
--- a/.changeset/selfish-poets-grab.md
+++ b/.changeset/selfish-poets-grab.md
@@ -1,0 +1,15 @@
+---
+"@dojoengine/sdk": patch
+"@dojoengine/core": patch
+"@dojoengine/create-burner": patch
+"@dojoengine/create-dojo": patch
+"@dojoengine/predeployed-connector": patch
+"@dojoengine/react": patch
+"@dojoengine/state": patch
+"@dojoengine/torii-client": patch
+"@dojoengine/torii-wasm": patch
+"@dojoengine/utils": patch
+"@dojoengine/utils-wasm": patch
+---
+
+fix: Add nested query test to match book + syntactic sugar

--- a/packages/sdk/src/clauseBuilder.ts
+++ b/packages/sdk/src/clauseBuilder.ts
@@ -8,6 +8,10 @@ import {
 import { convertToPrimitive } from "./convertToMemberValue";
 import { SchemaType } from "./types";
 
+type ClauseBuilderInterface = {
+    build(): Clause;
+};
+
 // Helper types for nested model structure
 type ModelPath<T, K extends keyof T> = K extends string
     ? T[K] extends Record<string, any>
@@ -27,6 +31,70 @@ type GetModelType<
             : never
         : never
     : never;
+
+/**
+ * Saves some keyboard strokes to get a KeysClause.
+ *
+ * @param models - the models you want to query, has to be in form of ns-Model
+ * @param keys - the keys that has the model. You can use `undefined` as a wildcard to match any key
+ * @param pattern - either VariableLen or FixedLen - to check exact match of key number
+ * @return ClauseBuilder<T>
+ */
+export function KeysClause<T extends SchemaType>(
+    models: ModelPath<T, keyof T>[],
+    keys: (string | undefined)[],
+    pattern: PatternMatching = "VariableLen"
+): ClauseBuilder<T> {
+    return new ClauseBuilder<T>().keys(models, keys, pattern);
+}
+
+/**
+ * Saves some keyboard strokes to get a MemberClause.
+ *
+ * @template T - the schema type
+ * @param model - the model you want to query, has to be in form of ns-Model
+ * @param member - the member of the model on which you want to apply operator
+ * @param operator - the operator to apply
+ * @param value - the value to operate on.
+ * @return ClauseBuilder<T>
+ */
+export function MemberClause<
+    T extends SchemaType,
+    Path extends ModelPath<T, keyof T>,
+    M extends keyof GetModelType<T, ModelPath<T, keyof T>>,
+>(
+    model: Path,
+    member: M & string,
+    operator: ComparisonOperator,
+    value: GetModelType<T, Path>[M] | GetModelType<T, Path>[M][]
+): ClauseBuilder<T> {
+    return new ClauseBuilder<T>().where(model, member, operator, value);
+}
+
+/**
+ * Saves some keyboard strokes to get a Composite "Or" Clause
+ *
+ * @template T - the schema type
+ * @param clauses - the inner clauses that you want to compose
+ * @return CompositeBuilder<T>
+ */
+export function AndComposeClause<T extends SchemaType>(
+    clauses: ClauseBuilderInterface[]
+): CompositeBuilder<T> {
+    return new ClauseBuilder<T>().compose().and(clauses);
+}
+
+/**
+ * Saves some keyboard strokes to get a Composite "And" Clause
+ * @template T - the schema type
+ * @param clauses - the inner clauses that you want to compose
+ * @return CompositeBuilder<T>
+ */
+export function OrComposeClause<T extends SchemaType>(
+    clauses: ClauseBuilderInterface[]
+): CompositeBuilder<T> {
+    return new ClauseBuilder<T>().compose().or(clauses);
+}
 
 export class ClauseBuilder<T extends SchemaType> {
     private clause: Clause;
@@ -103,12 +171,12 @@ class CompositeBuilder<T extends Record<string, Record<string, any>>> {
     private orClauses: Clause[] = [];
     private andClauses: Clause[] = [];
 
-    or(clauses: ClauseBuilder<T>[]): CompositeBuilder<T> {
+    or(clauses: ClauseBuilderInterface[]): CompositeBuilder<T> {
         this.orClauses = clauses.map((c) => c.build());
         return this;
     }
 
-    and(clauses: ClauseBuilder<T>[]): CompositeBuilder<T> {
+    and(clauses: ClauseBuilderInterface[]): CompositeBuilder<T> {
         this.andClauses = clauses.map((c) => c.build());
         return this;
     }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clause building functionality in Dojo Engine SDK
	- Added new utility functions for creating complex query clauses
	- Improved support for nested and composite query conditions

- **Improvements**
	- Updated method signatures for more flexible clause composition
	- Added new interface and type definitions to support advanced querying

- **Testing**
	- Expanded test suite for clause builder with complex composition scenarios
	- Added test cases to verify clause building usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->