### PR TITLE
fix: create store type differenciation

### DIFF
--- a/.changeset/friendly-emus-beam.md
+++ b/.changeset/friendly-emus-beam.md
@@ -1,0 +1,16 @@
+---
+"@dojoengine/sdk": patch
+"template-vite-ts": patch
+"@dojoengine/core": patch
+"@dojoengine/create-burner": patch
+"@dojoengine/create-dojo": patch
+"@dojoengine/predeployed-connector": patch
+"@dojoengine/react": patch
+"@dojoengine/state": patch
+"@dojoengine/torii-client": patch
+"@dojoengine/torii-wasm": patch
+"@dojoengine/utils": patch
+"@dojoengine/utils-wasm": patch
+---
+
+fix: createStore now fit to either vanilla or react store

--- a/packages/sdk/src/react/hooks.ts
+++ b/packages/sdk/src/react/hooks.ts
@@ -2,8 +2,9 @@ import { useContext } from "react";
 import { BigNumberish } from "starknet";
 import { SchemaType } from "../types";
 import { DojoContext, DojoContextType } from "./provider";
-import { create } from "zustand";
+import { create, StoreApi, UseBoundStore } from "zustand";
 import { createDojoStoreFactory } from "../state/zustand";
+import { GameState } from "../state";
 
 /**
  * Factory function to create a React Zustand store based on a given SchemaType.
@@ -12,7 +13,10 @@ import { createDojoStoreFactory } from "../state/zustand";
  * @returns A Zustand hook tailored to the provided schema.
  */
 export function createDojoStore<T extends SchemaType>() {
-    return createDojoStoreFactory<T>(create);
+    // hacktually until I find a proper type input to createDojoStoreFactory
+    return createDojoStoreFactory<T>(create) as unknown as UseBoundStore<
+        StoreApi<GameState<T>>
+    >;
 }
 
 /**

--- a/packages/sdk/src/state/zustand.ts
+++ b/packages/sdk/src/state/zustand.ts
@@ -1,4 +1,4 @@
-import { type StateCreator, type StoreApi } from "zustand";
+import { UseBoundStore, type StateCreator, type StoreApi } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { Draft, WritableDraft, applyPatches, produceWithPatches } from "immer";
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced type handling for the Zustand store, improving type safety and clarity.
	- Updated the `createStore` function to support both vanilla and React store implementations.
- **Chores**
	- Updated multiple Dojo Engine packages for improved functionality and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->