### PR TITLE
feat: add getControllers and update subscription functions

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -327,5 +327,64 @@ export async function init<T extends SchemaType>(
                 account_addresses
             );
         },
+
+        /**
+         * Updates an existing entity subscription
+         *
+         * # Parameters
+         * @param {torii.Subscription} subscription - Existing subscription to update
+         * @param {torii.EntityKeysClause[]} clauses - New array of key clauses for filtering
+         *
+         * # Returns
+         * Result containing unit or error
+         * @returns {Promise<void>}
+         */
+        updateEntitySubscription: async (
+            subscription: torii.Subscription,
+            clauses: torii.EntityKeysClause[]
+        ): Promise<void> => {
+            return await client.updateEntitySubscription(subscription, clauses);
+        },
+
+        /**
+         * Updates an existing event message subscription
+         *
+         * # Parameters
+         * @param {torii.Subscription} subscription - Existing subscription to update
+         * @param {torii.EntityKeysClause[]} clauses - New array of key clauses for filtering
+         * @param {boolean} historical - Whether to include historical messages
+         *
+         * # Returns
+         * Result containing unit or error
+         * @returns {Promise<void>}
+         */
+        updateEventMessageSubscription: async (
+            subscription: torii.Subscription,
+            clauses: torii.EntityKeysClause[],
+            historical: boolean
+        ): Promise<void> => {
+            return await client.updateEventMessageSubscription(
+                subscription,
+                clauses,
+                historical
+            );
+        },
+
+        /**
+         * Gets controllers along with their usernames for the given contract addresses
+         *
+         * # Parameters
+         * @param {string[]} contract_addresses - Array of contract addresses as hex strings. If empty, all
+         *   controllers will be returned.
+         *
+         * # Returns
+         * Result containing controllers or error
+         * @returns {Promise<torii.Controllers>}
+         */
+        getControllers: async (
+            contract_addresses: string[]
+        ): Promise<torii.Controllers> => {
+            return await client.getControllers(contract_addresses);
+        },
     };
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -378,6 +378,55 @@ export interface SDK<T extends SchemaType> {
         contract_addresses: string[],
         account_addresses: string[]
     ) => Promise<void>;
+
+    /**
+     * Updates an existing entity subscription
+     *
+     * # Parameters
+     * @param {torii.Subscription} subscription - Existing subscription to update
+     * @param {torii.EntityKeysClause[]} clauses - New array of key clauses for filtering
+     *
+     * # Returns
+     * Result containing unit or error
+     * @returns {Promise<void>}
+     */
+    updateEntitySubscription: (
+        subscription: torii.Subscription,
+        clauses: torii.EntityKeysClause[]
+    ) => Promise<void>;
+
+    /**
+     * Updates an existing event message subscription
+     *
+     * # Parameters
+     * @param {torii.Subscription} subscription - Existing subscription to update
+     * @param {torii.EntityKeysClause[]} clauses - New array of key clauses for filtering
+     * @param {boolean} historical - Whether to include historical messages
+     *
+     * # Returns
+     * Result containing unit or error
+     * @returns {Promise<void>}
+     */
+    updateEventMessageSubscription: (
+        subscription: torii.Subscription,
+        clauses: torii.EntityKeysClause[],
+        historical: boolean
+    ) => Promise<void>;
+
+    /**
+     * Gets controllers along with their usernames for the given contract addresses
+     *
+     * # Parameters
+     * @param {string[]} contract_addresses - Array of contract addresses as hex strings. If empty, all
+     *   controllers will be returned.
+     *
+     * # Returns
+     * Result containing controllers or error
+     * @returns {Promise<torii.Controllers>}
+     */
+    getControllers: (
+        contract_addresses: string[]
+    ) => Promise<torii.Controllers>;
 }
 
 /**


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced asynchronous methods to update both entity and event subscriptions with configurable filtering options.
	- Enabled the option to include historical data when updating event message subscriptions.
	- Added a feature to retrieve controller information based on specified contract addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->