### PR TITLE
fix: recs setEntities now updates component if component exists

### DIFF
--- a/.changeset/chatty-kings-nail.md
+++ b/.changeset/chatty-kings-nail.md
@@ -1,0 +1,16 @@
+---
+"@dojoengine/state": patch
+"template-vite-ts": patch
+"@dojoengine/core": patch
+"@dojoengine/create-burner": patch
+"@dojoengine/create-dojo": patch
+"@dojoengine/predeployed-connector": patch
+"@dojoengine/react": patch
+"@dojoengine/sdk": patch
+"@dojoengine/torii-client": patch
+"@dojoengine/torii-wasm": patch
+"@dojoengine/utils": patch
+"@dojoengine/utils-wasm": patch
+---
+
+fix: recs `setEntities` now updates component if component exists

--- a/packages/state/src/recs/index.ts
+++ b/packages/state/src/recs/index.ts
@@ -2,9 +2,12 @@ import {
     Component,
     ComponentValue,
     Entity,
+    getComponentValue,
+    hasComponent,
     Metadata,
     Schema,
     setComponent,
+    updateComponent,
 } from "@dojoengine/recs";
 import {
     Clause,
@@ -405,26 +408,23 @@ export const setEntities = async <S extends Schema>(
 
     if (logging) console.log("Entities to set:", entities);
 
-    for (let key in entities) {
+    for (const key in entities) {
         if (!Object.hasOwn(entities, key)) {
             continue;
         }
 
-        for (let componentName in entities[key]) {
+        for (const componentName in entities[key]) {
             if (!Object.hasOwn(entities[key], componentName)) {
                 continue;
             }
-            let recsComponent = Object.values(components).find(
-                (component) =>
-                    component.metadata?.namespace +
-                        "-" +
-                        component.metadata?.name ===
-                    componentName
+            const recsComponent = Object.values(components).find(
+                (component) => component.metadata?.name === componentName
             );
 
             if (recsComponent) {
                 try {
                     const rawValue = entities[key][componentName];
+
                     if (logging)
                         console.log(
                             `Raw value for ${componentName} on ${key}:`,
@@ -448,6 +448,19 @@ export const setEntities = async <S extends Schema>(
                         );
                     }
 
+                    if (hasComponent(recsComponent, key as Entity)) {
+                        updateComponent(
+                            recsComponent,
+                            key as Entity,
+                            convertedValue as Partial<ComponentValue>,
+                            getComponentValue(recsComponent, key as Entity)
+                        );
+                        if (logging)
+                            console.log(
+                                `Update component ${recsComponent.metadata?.name} on ${key}`
+                            );
+                        continue;
+                    }
                     setComponent(recsComponent, key as Entity, convertedValue);
 
                     if (logging)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated underlying dependencies with the latest patch updates to enhance overall system stability.

- **Bug Fixes**
  - Improved the component update process to ensure that existing components are properly refreshed instead of being inadvertently overwritten, leading to more consistent and reliable system behavior.
  
- **New Features**
  - Introduced new methods for enhanced component management: `getComponentValue`, `hasComponent`, and `updateComponent`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->