### PR TITLE
feat: add react hook to use predeployed accounts

### DIFF
--- a/.changeset/clean-tables-turn.md
+++ b/.changeset/clean-tables-turn.md
@@ -1,0 +1,5 @@
+---
+"@dojoengine/predeployed-connector": patch
+---
+
+feat: add react hook to get predeployed accounts

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs
 lerna-debug.log
 
 .turbo/
+**/**/vite.config.ts.timestamp-*

--- a/examples/example-predeployed-connector/src/starknet-provider.tsx
+++ b/examples/example-predeployed-connector/src/starknet-provider.tsx
@@ -1,31 +1,19 @@
-import { useEffect, useState, type PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import { mainnet } from "@starknet-react/chains";
 import { jsonRpcProvider, StarknetConfig, voyager } from "@starknet-react/core";
 import { dojoConfig } from "../dojoConfig";
-import {
-    predeployedAccounts,
-    type PredeployedAccountsConnector,
-} from "@dojoengine/predeployed-connector";
+import { usePredeployedAccounts } from "@dojoengine/predeployed-connector/react";
 
 export default function StarknetProvider({ children }: PropsWithChildren) {
-    const [retries, setRetries] = useState<number>(0);
-    const [connectors, setConnectors] = useState<
-        PredeployedAccountsConnector[]
-    >([]);
+    const { connectors } = usePredeployedAccounts({
+        rpc: dojoConfig.rpcUrl as string,
+        id: "katana",
+        name: "Katana",
+    });
+
     const provider = jsonRpcProvider({
         rpc: () => ({ nodeUrl: dojoConfig.rpcUrl as string }),
     });
-
-    useEffect(() => {
-        if (connectors.length === 0 && retries < 5) {
-            setRetries(retries + 1);
-            predeployedAccounts({
-                rpc: dojoConfig.rpcUrl as string,
-                id: "katana",
-                name: "Katana",
-            }).then(setConnectors);
-        }
-    }, [connectors]);
 
     return (
         <StarknetConfig

--- a/examples/example-vite-kitchen-sink/src/components/starknet-provider.tsx
+++ b/examples/example-vite-kitchen-sink/src/components/starknet-provider.tsx
@@ -1,20 +1,16 @@
 import type { PropsWithChildren } from "react";
 import { mainnet } from "@starknet-react/chains";
 import { jsonRpcProvider, StarknetConfig, voyager } from "@starknet-react/core";
-import { env, getRpcUrl } from "@/env";
-import {
-    predeployedAccounts,
-    PredeployedAccountsConnector,
-} from "@dojoengine/predeployed-connector";
-
-let pa: PredeployedAccountsConnector[] = [];
-predeployedAccounts({
-    rpc: env.VITE_CONTROLLER_RPC,
-    id: "katana",
-    name: "Katana",
-}).then((p) => (pa = p));
+import { getRpcUrl } from "@/env";
+import { usePredeployedAccounts } from "@dojoengine/predeployed-connector/react";
+import { dojoConfig } from "../../dojoConfig";
 
 export default function StarknetProvider({ children }: PropsWithChildren) {
+    const { connectors } = usePredeployedAccounts({
+        rpc: dojoConfig.rpcUrl as string,
+        id: "katana",
+        name: "Katana",
+    });
     const provider = jsonRpcProvider({
         rpc: () => ({ nodeUrl: getRpcUrl() }),
     });
@@ -23,7 +19,7 @@ export default function StarknetProvider({ children }: PropsWithChildren) {
         <StarknetConfig
             chains={[mainnet]}
             provider={provider}
-            connectors={[...pa]}
+            connectors={[...connectors]}
             explorer={voyager}
             autoConnect
         >

--- a/examples/example-vite-react-app-recs/package.json
+++ b/examples/example-vite-react-app-recs/package.json
@@ -26,7 +26,6 @@
         "react-dom": "^18.3.1",
         "rxjs": "^7.8.1",
         "starknet": "catalog:",
-        "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.3.0"
     },
     "devDependencies": {
@@ -43,6 +42,7 @@
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.13",
         "typescript": "^5.6.2",
-        "vite": "^4.5.5"
+        "vite": "^4.5.5",
+        "vite-plugin-top-level-await": "^1.4.4"
     }
 }

--- a/examples/example-vite-react-phaser-recs/package.json
+++ b/examples/example-vite-react-phaser-recs/package.json
@@ -39,7 +39,6 @@
         "styled-components": "^6.1.14",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
-        "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.4.1",
         "zustand": "^4.5.6"
     },
@@ -57,6 +56,7 @@
         "postcss": "^8.5.1",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.3",
-        "vite": "^6.0.11"
+        "vite": "^6.0.11",
+        "vite-plugin-top-level-await": "^1.4.4"
     }
 }

--- a/examples/example-vite-react-sdk/package.json
+++ b/examples/example-vite-react-sdk/package.json
@@ -28,7 +28,6 @@
         "react-dom": "catalog:",
         "starknet": "catalog:",
         "uuid": "^10.0.0",
-        "vite-plugin-top-level-await": "^1.5.0",
         "vite-plugin-wasm": "^3.4.1",
         "zustand": "^4.5.6"
     },
@@ -46,6 +45,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.24.1",
-        "vite": "^5.4.14"
+        "vite": "^5.4.14",
+        "vite-plugin-top-level-await": "^1.5.0"
     }
 }

--- a/examples/example-vite-react-sdk/src/starknet-provider.tsx
+++ b/examples/example-vite-react-sdk/src/starknet-provider.tsx
@@ -1,25 +1,16 @@
 import type { PropsWithChildren } from "react";
 import { mainnet } from "@starknet-react/chains";
-import {
-    type Connector,
-    jsonRpcProvider,
-    StarknetConfig,
-    voyager,
-} from "@starknet-react/core";
+import { jsonRpcProvider, StarknetConfig, voyager } from "@starknet-react/core";
 import { dojoConfig } from "../dojoConfig";
-import {
-    predeployedAccounts,
-    type PredeployedAccountsConnector,
-} from "@dojoengine/predeployed-connector";
-
-let pa: PredeployedAccountsConnector[] = [];
-predeployedAccounts({
-    rpc: dojoConfig.rpcUrl as string,
-    id: "katana",
-    name: "Katana",
-}).then((p) => (pa = p));
+import { usePredeployedAccounts } from "@dojoengine/predeployed-connector/react";
 
 export default function StarknetProvider({ children }: PropsWithChildren) {
+    const { connectors } = usePredeployedAccounts({
+        rpc: dojoConfig.rpcUrl as string,
+        id: "katana",
+        name: "Katana",
+    });
+
     const provider = jsonRpcProvider({
         rpc: () => ({ nodeUrl: dojoConfig.rpcUrl as string }),
     });
@@ -28,7 +19,7 @@ export default function StarknetProvider({ children }: PropsWithChildren) {
         <StarknetConfig
             chains={[mainnet]}
             provider={provider}
-            connectors={pa as unknown as Connector[]}
+            connectors={connectors}
             explorer={voyager}
             autoConnect
         >

--- a/examples/example-vite-react-sql/src/components/starknet-provider.tsx
+++ b/examples/example-vite-react-sql/src/components/starknet-provider.tsx
@@ -1,29 +1,18 @@
-import { useEffect, useState, type PropsWithChildren } from "react";
+import { type PropsWithChildren } from "react";
 import { mainnet } from "@starknet-react/chains";
 import { jsonRpcProvider, StarknetConfig, voyager } from "@starknet-react/core";
 import { dojoConfig } from "../../dojoConfig";
-import {
-    predeployedAccounts,
-    PredeployedAccountsConnector,
-} from "@dojoengine/predeployed-connector";
+import { usePredeployedAccounts } from "@dojoengine/predeployed-connector/react";
 
 export default function StarknetProvider({ children }: PropsWithChildren) {
-    const [connectors, setConnectors] = useState<
-        PredeployedAccountsConnector[]
-    >([]);
+    const { connectors } = usePredeployedAccounts({
+        rpc: dojoConfig.rpcUrl as string,
+        id: "katana",
+        name: "Katana",
+    });
     const provider = jsonRpcProvider({
         rpc: () => ({ nodeUrl: dojoConfig.rpcUrl as string }),
     });
-
-    useEffect(() => {
-        if (connectors.length === 0) {
-            predeployedAccounts({
-                rpc: dojoConfig.rpcUrl as string,
-                id: "katana",
-                name: "Katana",
-            }).then(setConnectors);
-        }
-    }, [connectors]);
 
     return (
         <StarknetConfig

--- a/examples/example-vite-react-threejs-recs/package.json
+++ b/examples/example-vite-react-threejs-recs/package.json
@@ -54,7 +54,6 @@
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.160.1",
         "vite-plugin-svgr": "^4.2.0",
-        "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.3.0",
         "zustand": "^4.5.5"
     },
@@ -79,6 +78,7 @@
         "eslint-plugin-storybook": "^0.6.15",
         "storybook": "^7.6.20",
         "typescript": "^5.6.2",
-        "vite": "^4.5.5"
+        "vite": "^4.5.5",
+        "vite-plugin-top-level-await": "^1.4.4"
     }
 }

--- a/examples/example-vite-svelte-recs/package.json
+++ b/examples/example-vite-svelte-recs/package.json
@@ -16,7 +16,8 @@
         "svelte-check": "^3.8.5",
         "tslib": "^2.6.3",
         "typescript": "^5.5.3",
-        "vite": "^5.4.1"
+        "vite": "^5.4.1",
+        "vite-plugin-top-level-await": "^1.4.4"
     },
     "dependencies": {
         "@dojoengine/core": "workspace:*",
@@ -27,7 +28,6 @@
         "@dojoengine/utils": "workspace:*",
         "@latticexyz/utils": "^2.1.1",
         "starknet": "catalog:",
-        "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.3.0"
     }
 }

--- a/examples/example-vue-app-recs/package.json
+++ b/examples/example-vue-app-recs/package.json
@@ -22,7 +22,6 @@
         "@dojoengine/utils": "workspace:*",
         "@latticexyz/utils": "^2.2.8",
         "starknet": "catalog:",
-        "vite-plugin-top-level-await": "^1.4.4",
         "vite-plugin-wasm": "^3.3.0",
         "vue": "^3.5.8"
     },
@@ -30,6 +29,7 @@
         "@vitejs/plugin-vue": "^5.1.4",
         "typescript": "^5.6.2",
         "vite": "^5.4.7",
+        "vite-plugin-top-level-await": "^1.4.4",
         "vue-tsc": "^2.1.6"
     }
 }

--- a/packages/predeployed-connector/package.json
+++ b/packages/predeployed-connector/package.json
@@ -21,11 +21,17 @@
             "import": "./dist/index.js",
             "types": "./dist/index.d.ts"
         },
+        "./react": {
+            "import": "./dist/src/react.js",
+            "types": "./dist/src/react.d.ts"
+        },
         "./package.json": "./package.json"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.0",
         "@vitest/coverage-v8": "^1.6.0",
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
         "eslint": "^8.57.1",
         "prettier": "^2.8.8",
         "tsup": "^8.3.0",
@@ -35,7 +41,9 @@
     },
     "peerDependencies": {
         "@starknet-react/core": "catalog:",
-        "starknet": "catalog:"
+        "starknet": "catalog:",
+        "react": "catalog:",
+        "react-dom": "catalog:"
     },
     "repository": {
         "type": "git",

--- a/packages/predeployed-connector/src/react/index.ts
+++ b/packages/predeployed-connector/src/react/index.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useState } from "react";
+import {
+    predeployedAccounts,
+    type PredeployedAccountsConnector,
+    type PredeployedAccountsConnectorOptions,
+} from "..";
+
+/**
+ * Hook for fetching predeployed accounts.
+ *
+ * @param options - The options for the predeployed accounts.
+ * @returns The predeployed accounts.
+ */
+export function usePredeployedAccounts(
+    options: PredeployedAccountsConnectorOptions
+) {
+    const [retries, setRetries] = useState<number>(0);
+    const [connectors, setConnectors] = useState<
+        PredeployedAccountsConnector[]
+    >([]);
+
+    useEffect(() => {
+        if (connectors.length === 0 && retries < 5) {
+            setRetries(retries + 1);
+            predeployedAccounts(options).then(setConnectors);
+        }
+    }, [connectors, options]);
+
+    return { connectors };
+}

--- a/packages/predeployed-connector/tsup.config.ts
+++ b/packages/predeployed-connector/tsup.config.ts
@@ -4,4 +4,8 @@ import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
     ...(tsupConfig as Options),
+    entry: {
+        index: "src/index.ts",
+        "src/react": "src/react/index.ts",
+    },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^18.6.1
-        version: 18.6.1(@types/node@22.13.1)(typescript@5.7.3)
+        version: 18.6.1(@types/node@22.13.1)(typescript@5.8.2)
       '@commitlint/config-conventional':
         specifier: ^18.6.3
         version: 18.6.3
@@ -50,7 +50,7 @@ importers:
         version: 4.4.1(@vue/compiler-sfc@3.5.13)(prettier@3.4.2)
       '@typhonjs-typedoc/typedoc-theme-dmt':
         specifier: ^0.2.3
-        version: 0.2.3(typedoc@0.26.11(typescript@5.7.3))
+        version: 0.2.3(typedoc@0.26.11(typescript@5.8.2))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -62,19 +62,19 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@swc/core@1.10.18(@swc/helpers@0.5.5))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
+        version: 8.3.5(@swc/core@1.10.18(@swc/helpers@0.5.5))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.2)(typescript@5.8.2)(yaml@2.7.0)
       turbo:
         specifier: ^2.4.4
         version: 2.4.4
       typedoc:
         specifier: ^0.26.11
-        version: 0.26.11(typescript@5.7.3)
+        version: 0.26.11(typescript@5.8.2)
       typedoc-plugin-coverage:
         specifier: ^3.4.1
-        version: 3.4.1(typedoc@0.26.11(typescript@5.7.3))
+        version: 3.4.1(typedoc@0.26.11(typescript@5.8.2))
       typedoc-plugin-missing-exports:
         specifier: ^3.1.0
-        version: 3.1.0(typedoc@0.26.11(typescript@5.7.3))
+        version: 3.1.0(typedoc@0.26.11(typescript@5.8.2))
 
   examples/example-nodejs-bot:
     dependencies:
@@ -138,7 +138,7 @@ importers:
         version: 3.0.11
       bun-types:
         specifier: latest
-        version: 1.2.4
+        version: 1.2.5
       graphql:
         specifier: ^16.9.0
         version: 16.10.0
@@ -586,9 +586,6 @@ importers:
       starknet:
         specifier: 'catalog:'
         version: 6.21.0(encoding@0.1.13)
-      vite-plugin-top-level-await:
-        specifier: ^1.4.4
-        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0))
       vite-plugin-wasm:
         specifier: ^3.3.0
         version: 3.4.1(vite@4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0))
@@ -635,6 +632,9 @@ importers:
       vite:
         specifier: ^4.5.5
         version: 4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.4.4
+        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0))
 
   examples/example-vite-react-phaser-recs:
     dependencies:
@@ -722,9 +722,6 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
-      vite-plugin-top-level-await:
-        specifier: ^1.4.4
-        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@6.0.11(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       vite-plugin-wasm:
         specifier: ^3.4.1
         version: 3.4.1(vite@6.0.11(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
@@ -774,6 +771,9 @@ importers:
       vite:
         specifier: ^6.0.11
         version: 6.0.11(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.4.4
+        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@6.0.11(@types/node@20.17.14)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
 
   examples/example-vite-react-pwa-recs:
     dependencies:
@@ -937,9 +937,6 @@ importers:
       uuid:
         specifier: ^10.0.0
         version: 10.0.0
-      vite-plugin-top-level-await:
-        specifier: ^1.5.0
-        version: 1.5.0(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
       vite-plugin-wasm:
         specifier: ^3.4.1
         version: 3.4.1(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
@@ -989,6 +986,9 @@ importers:
       vite:
         specifier: ^5.4.14
         version: 5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.5.0
+        version: 1.5.0(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@5.4.14(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
 
   examples/example-vite-react-sql:
     dependencies:
@@ -1051,7 +1051,7 @@ importers:
         version: 2.1.1
       drizzle-orm:
         specifier: ^0.38.3
-        version: 0.38.3(@libsql/client@0.14.0)(@types/react@18.3.18)(bun-types@1.2.4)(react@18.3.1)
+        version: 0.38.3(@libsql/client@0.14.0)(@types/react@18.3.18)(bun-types@1.2.5)(react@18.3.1)
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@18.3.1)
@@ -1251,9 +1251,6 @@ importers:
       vite-plugin-svgr:
         specifier: ^4.2.0
         version: 4.3.0(rollup@4.34.9)(typescript@5.7.2)(vite@4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0))
-      vite-plugin-top-level-await:
-        specifier: ^1.4.4
-        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0))
       vite-plugin-wasm:
         specifier: ^3.3.0
         version: 3.4.1(vite@4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0))
@@ -1324,6 +1321,9 @@ importers:
       vite:
         specifier: ^4.5.5
         version: 4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.4.4
+        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@4.5.5(@types/node@20.17.10)(lightningcss@1.29.1)(terser@5.39.0))
 
   examples/example-vite-svelte-recs:
     dependencies:
@@ -1351,9 +1351,6 @@ importers:
       starknet:
         specifier: 'catalog:'
         version: 6.21.0(encoding@0.1.13)
-      vite-plugin-top-level-await:
-        specifier: ^1.4.4
-        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@5.4.11(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
       vite-plugin-wasm:
         specifier: ^3.3.0
         version: 3.4.1(vite@5.4.11(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
@@ -1379,6 +1376,9 @@ importers:
       vite:
         specifier: ^5.4.1
         version: 5.4.11(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.4.4
+        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@5.4.11(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
 
   examples/example-vue-app-recs:
     dependencies:
@@ -1409,9 +1409,6 @@ importers:
       starknet:
         specifier: 'catalog:'
         version: 6.21.0(encoding@0.1.13)
-      vite-plugin-top-level-await:
-        specifier: ^1.4.4
-        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@5.4.11(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
       vite-plugin-wasm:
         specifier: ^3.3.0
         version: 3.4.1(vite@5.4.11(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
@@ -1428,6 +1425,9 @@ importers:
       vite:
         specifier: ^5.4.7
         version: 5.4.11(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.4.4
+        version: 1.4.4(@swc/helpers@0.5.5)(rollup@4.34.9)(vite@5.4.11(@types/node@22.13.1)(lightningcss@1.29.1)(terser@5.39.0))
       vue-tsc:
         specifier: ^2.1.6
         version: 2.2.0(typescript@5.7.2)
@@ -1595,17 +1595,29 @@ importers:
         version: 0.7.10
       '@starknet-react/core':
         specifier: 'catalog:'
-        version: 3.6.2(get-starknet-core@4.0.0)(react@19.0.0)(starknet@6.21.0(encoding@0.1.13))(typescript@5.7.2)
+        version: 3.6.2(get-starknet-core@4.0.0)(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))(typescript@5.7.3)
+      react:
+        specifier: 'catalog:'
+        version: 18.3.1
+      react-dom:
+        specifier: 'catalog:'
+        version: 18.3.1(react@18.3.1)
       starknet:
         specifier: 'catalog:'
         version: 6.21.0(encoding@0.1.13)
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^28.0.0
-        version: 28.0.2(rollup@4.34.9)
+        version: 28.0.3(rollup@4.34.9)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.18
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 18.3.5(@types/react@18.3.18)
       '@vitest/coverage-v8':
         specifier: ^1.6.0
-        version: 1.6.0(vitest@1.6.0(@types/node@22.13.1)(jsdom@24.1.3)(lightningcss@1.29.1)(terser@5.39.0))
+        version: 1.6.1(vitest@1.6.1(@types/node@22.13.1)(jsdom@24.1.3)(lightningcss@1.29.1)(terser@5.39.0))
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -1614,16 +1626,16 @@ importers:
         version: 2.8.8
       tsup:
         specifier: ^8.3.0
-        version: 8.3.5(@swc/core@1.10.18(@swc/helpers@0.5.5))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.7.0)
+        version: 8.4.0(@swc/core@1.10.18(@swc/helpers@0.5.5))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
       typescript:
         specifier: ^5.6.2
-        version: 5.7.2
+        version: 5.7.3
       vite:
         specifier: ^3.2.11
         version: 3.2.11(@types/node@22.13.1)(terser@5.39.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.0(@types/node@22.13.1)(jsdom@24.1.3)(lightningcss@1.29.1)(terser@5.39.0)
+        version: 1.6.1(@types/node@22.13.1)(jsdom@24.1.3)(lightningcss@1.29.1)(terser@5.39.0)
 
   packages/react:
     dependencies:
@@ -1935,6 +1947,10 @@ packages:
     resolution: {integrity: sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.26.10':
+    resolution: {integrity: sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.26.3':
     resolution: {integrity: sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==}
     engines: {node: '>=6.9.0'}
@@ -2041,6 +2057,11 @@ packages:
   '@babel/helpers@7.26.9':
     resolution: {integrity: sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.26.10':
+    resolution: {integrity: sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   '@babel/parser@7.26.3':
     resolution: {integrity: sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==}
@@ -2570,8 +2591,8 @@ packages:
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.26.9':
-    resolution: {integrity: sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==}
+  '@babel/runtime@7.26.10':
+    resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.25.9':
@@ -2580,6 +2601,10 @@ packages:
 
   '@babel/template@7.26.9':
     resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.26.10':
+    resolution: {integrity: sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.26.4':
@@ -2592,6 +2617,10 @@ packages:
 
   '@babel/traverse@7.26.9':
     resolution: {integrity: sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.10':
+    resolution: {integrity: sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.3':
@@ -5877,6 +5906,15 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/plugin-commonjs@28.0.3':
+    resolution: {integrity: sha512-pyltgilam1QPdn+Zd9gaCfOLcnjMEJ9gV+bTw6/r73INdvzf1ah9zLIJBm+kW7R6IUFIQ1YO+VqZtYxZNWFPEQ==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/plugin-node-resolve@15.3.1':
     resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
     engines: {node: '>=14.0.0'}
@@ -6656,6 +6694,9 @@ packages:
   '@starknet-react/chains@3.1.0':
     resolution: {integrity: sha512-h+fxh+Bs8h0ZSEX651vG3mn1NtMKzFDSHqrX7Q8YRRIeTKolPCx4vmoi5Gg19SXr/9iIVSwgx6qe4rVZTNfhcQ==}
 
+  '@starknet-react/chains@3.1.2':
+    resolution: {integrity: sha512-/Oldb4AVYdvHXzlBRxu01s0WwdOjqL2Q47BAmiv07/aBRU7mSZl6r/6l+bYKNrChSZl7WVnlpb+ojfwhRpbGcw==}
+
   '@starknet-react/core@3.6.2':
     resolution: {integrity: sha512-cEheoYB8Sy65+su1A7WzdyX/Qq89wLQXFmqOwsaIwpKNy1zzcwZfEOStCpzs6jLh7yEy3QU6arbn7wytt5OhKQ==}
     peerDependencies:
@@ -7203,8 +7244,8 @@ packages:
   '@tanstack/query-core@5.66.4':
     resolution: {integrity: sha512-skM/gzNX4shPkqmdTCSoHtJAPMTtmIJNS0hE+xwTTUVYwezArCT34NMermABmBVUg5Ls5aiUXEDXfqwR1oVkcA==}
 
-  '@tanstack/query-core@5.67.2':
-    resolution: {integrity: sha512-+iaFJ/pt8TaApCk6LuZ0WHS/ECVfTzrxDOEL9HH9Dayyb5OVuomLzDXeSaI2GlGT/8HN7bDGiRXDts3LV+u6ww==}
+  '@tanstack/query-core@5.67.3':
+    resolution: {integrity: sha512-pq76ObpjcaspAW4OmCbpXLF6BCZP2Zr/J5ztnyizXhSlNe7fIUp0QKZsd0JMkw9aDa+vxDX/OY7N+hjNY/dCGg==}
 
   '@tanstack/react-query@5.64.1':
     resolution: {integrity: sha512-vW5ggHpIO2Yjj44b4sB+Fd3cdnlMJppXRBJkEHvld6FXh3j5dwWJoQo7mGtKI2RbSFyiyu/PhGAy0+Vv5ev9Eg==}
@@ -7216,8 +7257,8 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-query@5.67.2':
-    resolution: {integrity: sha512-6Sa+BVNJWhAV4QHvIqM73norNeGRWGC3ftN0Ix87cmMvI215I1wyJ44KUTt/9a0V9YimfGcg25AITaYVel71Og==}
+  '@tanstack/react-query@5.67.3':
+    resolution: {integrity: sha512-u/n2HsQeH1vpZIOzB/w2lqKlXUDUKo6BxTdGXSMvNzIq5MHYFckRMVuFABp+QB7RN8LFXWV6X1/oSkuDq+MPIA==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -8605,8 +8646,8 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  bun-types@1.2.4:
-    resolution: {integrity: sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q==}
+  bun-types@1.2.5:
+    resolution: {integrity: sha512-3oO6LVGGRRKI4kHINx5PIdIgnLRb7l/SprhzqXapmoYkFl5m4j6EvALvbDVuuBFaamB46Ap6HCUxIXNLCGy+tg==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -12593,8 +12634,8 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  ox@0.6.7:
-    resolution: {integrity: sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==}
+  ox@0.6.9:
+    resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -13902,6 +13943,9 @@ packages:
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
+  std-env@3.8.1:
+    resolution: {integrity: sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -14641,6 +14685,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ua-parser-js@1.0.40:
     resolution: {integrity: sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==}
     hasBin: true
@@ -14896,8 +14945,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.23.7:
-    resolution: {integrity: sha512-Gbyz0uE3biWDPxECrEyzILWPsnIgDREgfRMuLSWHSSnM6ktefSC/lqQNImnxESdDEixa8/6EWXjmf2H6L9VV0A==}
+  viem@2.23.10:
+    resolution: {integrity: sha512-va6Wde+v96PdfzdPEspCML1MjAqe+88O8BD+R9Kun/4s5KMUNcqfHbXdZP0ZZ2Zms80styvH2pDRAqCho6TqkA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -15600,6 +15649,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -15871,6 +15932,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/generator@7.26.10':
+    dependencies:
+      '@babel/parser': 7.26.10
+      '@babel/types': 7.26.10
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.1.0
+
   '@babel/generator@7.26.3':
     dependencies:
       '@babel/parser': 7.26.5
@@ -16084,6 +16153,10 @@ snapshots:
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
 
+  '@babel/parser@7.26.10':
+    dependencies:
+      '@babel/types': 7.26.10
+
   '@babel/parser@7.26.3':
     dependencies:
       '@babel/types': 7.26.3
@@ -16291,7 +16364,7 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.9)
-      '@babel/traverse': 7.26.9
+      '@babel/traverse': 7.26.10
     transitivePeerDependencies:
       - supports-color
 
@@ -17253,7 +17326,7 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/runtime@7.26.9':
+  '@babel/runtime@7.26.10':
     dependencies:
       regenerator-runtime: 0.14.1
 
@@ -17268,6 +17341,18 @@ snapshots:
       '@babel/code-frame': 7.26.2
       '@babel/parser': 7.26.9
       '@babel/types': 7.26.9
+
+  '@babel/traverse@7.26.10':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.10
+      '@babel/parser': 7.26.10
+      '@babel/template': 7.26.9
+      '@babel/types': 7.26.10
+      debug: 4.4.0
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@7.26.4':
     dependencies:
@@ -17304,6 +17389,11 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/types@7.26.10':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@babel/types@7.26.3':
     dependencies:
@@ -17471,11 +17561,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@18.6.1(@types/node@22.13.1)(typescript@5.7.3)':
+  '@commitlint/cli@18.6.1(@types/node@22.13.1)(typescript@5.8.2)':
     dependencies:
       '@commitlint/format': 18.6.1
       '@commitlint/lint': 18.6.1
-      '@commitlint/load': 18.6.1(@types/node@22.13.1)(typescript@5.7.3)
+      '@commitlint/load': 18.6.1(@types/node@22.13.1)(typescript@5.8.2)
       '@commitlint/read': 18.6.1
       '@commitlint/types': 18.6.1
       execa: 5.1.1
@@ -17525,15 +17615,15 @@ snapshots:
       '@commitlint/rules': 18.6.1
       '@commitlint/types': 18.6.1
 
-  '@commitlint/load@18.6.1(@types/node@22.13.1)(typescript@5.7.3)':
+  '@commitlint/load@18.6.1(@types/node@22.13.1)(typescript@5.8.2)':
     dependencies:
       '@commitlint/config-validator': 18.6.1
       '@commitlint/execute-rule': 18.6.1
       '@commitlint/resolve-extends': 18.6.1
       '@commitlint/types': 18.6.1
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.7.3)
-      cosmiconfig-typescript-loader: 5.1.0(@types/node@22.13.1)(cosmiconfig@8.3.6(typescript@5.7.3))(typescript@5.7.3)
+      cosmiconfig: 8.3.6(typescript@5.8.2)
+      cosmiconfig-typescript-loader: 5.1.0(@types/node@22.13.1)(cosmiconfig@8.3.6(typescript@5.8.2))(typescript@5.8.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -19574,7 +19664,7 @@ snapshots:
       proxy-deep: 3.1.1
       rxjs: 7.5.5
 
-  '@lerna/create@8.1.9(@swc/core@1.10.18(@swc/helpers@0.5.5))(encoding@0.1.13)(typescript@5.7.3)':
+  '@lerna/create@8.1.9(@swc/core@1.10.18(@swc/helpers@0.5.5))(encoding@0.1.13)(typescript@5.8.2)':
     dependencies:
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
@@ -19592,7 +19682,7 @@ snapshots:
       console-control-strings: 1.1.0
       conventional-changelog-core: 5.0.1
       conventional-recommended-bump: 7.0.1
-      cosmiconfig: 9.0.0(typescript@5.7.3)
+      cosmiconfig: 9.0.0(typescript@5.8.2)
       dedent: 1.5.3
       execa: 5.0.0
       fs-extra: 11.2.0
@@ -19693,7 +19783,7 @@ snapshots:
   '@libsql/isomorphic-ws@0.1.5':
     dependencies:
       '@types/ws': 8.5.13
-      ws: 8.18.0
+      ws: 8.18.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -21118,6 +21208,18 @@ snapshots:
     optionalDependencies:
       rollup: 4.34.9
 
+  '@rollup/plugin-commonjs@28.0.3(rollup@4.34.9)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.34.9)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.4.3(picomatch@4.0.2)
+      is-reference: 1.2.1
+      magic-string: 0.30.17
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.34.9
+
   '@rollup/plugin-node-resolve@15.3.1(rollup@2.79.2)':
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
@@ -21713,16 +21815,18 @@ snapshots:
 
   '@starknet-react/chains@3.1.0': {}
 
+  '@starknet-react/chains@3.1.2': {}
+
   '@starknet-react/core@3.6.2(get-starknet-core@4.0.0)(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))(typescript@5.7.2)':
     dependencies:
       '@starknet-io/types-js': 0.7.10
-      '@starknet-react/chains': 3.1.0
-      '@tanstack/react-query': 5.67.2(react@18.3.1)
+      '@starknet-react/chains': 3.1.2
+      '@tanstack/react-query': 5.67.3(react@18.3.1)
       eventemitter3: 5.0.1
       get-starknet-core: 4.0.0
       react: 18.3.1
       starknet: 6.21.0(encoding@0.1.13)
-      viem: 2.23.7(typescript@5.7.2)(zod@3.24.2)
+      viem: 2.23.10(typescript@5.7.2)(zod@3.24.2)
       zod: 3.24.2
     transitivePeerDependencies:
       - bufferutil
@@ -21732,29 +21836,13 @@ snapshots:
   '@starknet-react/core@3.6.2(get-starknet-core@4.0.0)(react@18.3.1)(starknet@6.21.0(encoding@0.1.13))(typescript@5.7.3)':
     dependencies:
       '@starknet-io/types-js': 0.7.10
-      '@starknet-react/chains': 3.1.0
-      '@tanstack/react-query': 5.67.2(react@18.3.1)
+      '@starknet-react/chains': 3.1.2
+      '@tanstack/react-query': 5.67.3(react@18.3.1)
       eventemitter3: 5.0.1
       get-starknet-core: 4.0.0
       react: 18.3.1
       starknet: 6.21.0(encoding@0.1.13)
-      viem: 2.23.7(typescript@5.7.3)(zod@3.24.2)
-      zod: 3.24.2
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-
-  '@starknet-react/core@3.6.2(get-starknet-core@4.0.0)(react@19.0.0)(starknet@6.21.0(encoding@0.1.13))(typescript@5.7.2)':
-    dependencies:
-      '@starknet-io/types-js': 0.7.10
-      '@starknet-react/chains': 3.1.0
-      '@tanstack/react-query': 5.67.2(react@19.0.0)
-      eventemitter3: 5.0.1
-      get-starknet-core: 4.0.0
-      react: 19.0.0
-      starknet: 6.21.0(encoding@0.1.13)
-      viem: 2.23.7(typescript@5.7.2)(zod@3.24.2)
+      viem: 2.23.10(typescript@5.7.3)(zod@3.24.2)
       zod: 3.24.2
     transitivePeerDependencies:
       - bufferutil
@@ -22145,7 +22233,7 @@ snapshots:
       util: 0.12.5
       util-deprecate: 1.0.2
       watchpack: 2.4.2
-      ws: 8.18.0
+      ws: 8.18.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -22655,7 +22743,7 @@ snapshots:
 
   '@tanstack/query-core@5.66.4': {}
 
-  '@tanstack/query-core@5.67.2': {}
+  '@tanstack/query-core@5.67.3': {}
 
   '@tanstack/react-query@5.64.1(react@18.3.1)':
     dependencies:
@@ -22667,15 +22755,10 @@ snapshots:
       '@tanstack/query-core': 5.66.4
       react: 18.3.1
 
-  '@tanstack/react-query@5.67.2(react@18.3.1)':
+  '@tanstack/react-query@5.67.3(react@18.3.1)':
     dependencies:
-      '@tanstack/query-core': 5.67.2
+      '@tanstack/query-core': 5.67.3
       react: 18.3.1
-
-  '@tanstack/react-query@5.67.2(react@19.0.0)':
-    dependencies:
-      '@tanstack/query-core': 5.67.2
-      react: 19.0.0
 
   '@tanstack/react-router@1.97.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -22749,7 +22832,7 @@ snapshots:
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.26.10
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -23609,10 +23692,10 @@ snapshots:
       '@typescript-eslint/types': 8.26.0
       eslint-visitor-keys: 4.2.0
 
-  '@typhonjs-typedoc/typedoc-theme-dmt@0.2.3(typedoc@0.26.11(typescript@5.7.3))':
+  '@typhonjs-typedoc/typedoc-theme-dmt@0.2.3(typedoc@0.26.11(typescript@5.8.2))':
     dependencies:
       cheerio: 1.0.0
-      typedoc: 0.26.11(typescript@5.7.3)
+      typedoc: 0.26.11(typescript@5.8.2)
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -23794,7 +23877,7 @@ snapshots:
       magic-string: 0.30.17
       magicast: 0.3.5
       picocolors: 1.1.1
-      std-env: 3.8.0
+      std-env: 3.8.1
       strip-literal: 2.1.1
       test-exclude: 6.0.0
       vitest: 1.6.1(@types/node@22.13.1)(jsdom@24.1.3)(lightningcss@1.29.1)(terser@5.39.0)
@@ -24660,7 +24743,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bun-types@1.2.4:
+  bun-types@1.2.5:
     dependencies:
       '@types/node': 20.17.10
       '@types/ws': 8.5.13
@@ -25154,12 +25237,12 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@5.1.0(@types/node@22.13.1)(cosmiconfig@8.3.6(typescript@5.7.3))(typescript@5.7.3):
+  cosmiconfig-typescript-loader@5.1.0(@types/node@22.13.1)(cosmiconfig@8.3.6(typescript@5.8.2))(typescript@5.8.2):
     dependencies:
       '@types/node': 22.13.1
-      cosmiconfig: 8.3.6(typescript@5.7.3)
+      cosmiconfig: 8.3.6(typescript@5.8.2)
       jiti: 1.21.7
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   cosmiconfig@8.3.6(typescript@5.7.2):
     dependencies:
@@ -25170,23 +25253,23 @@ snapshots:
     optionalDependencies:
       typescript: 5.7.2
 
-  cosmiconfig@8.3.6(typescript@5.7.3):
+  cosmiconfig@8.3.6(typescript@5.8.2):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
-  cosmiconfig@9.0.0(typescript@5.7.3):
+  cosmiconfig@9.0.0(typescript@5.8.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: 5.8.2
 
   cross-env@7.0.3:
     dependencies:
@@ -25531,11 +25614,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.3(@libsql/client@0.14.0)(@types/react@18.3.18)(bun-types@1.2.4)(react@18.3.1):
+  drizzle-orm@0.38.3(@libsql/client@0.14.0)(@types/react@18.3.18)(bun-types@1.2.5)(react@18.3.1):
     optionalDependencies:
       '@libsql/client': 0.14.0
       '@types/react': 18.3.18
-      bun-types: 1.2.4
+      bun-types: 1.2.5
       react: 18.3.1
 
   dset@3.1.4: {}
@@ -27672,6 +27755,10 @@ snapshots:
     dependencies:
       ws: 8.18.0
 
+  isows@1.0.6(ws@8.18.1):
+    dependencies:
+      ws: 8.18.1
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.2.1:
@@ -28003,7 +28090,7 @@ snapshots:
 
   lerna@8.1.9(@swc/core@1.10.18(@swc/helpers@0.5.5))(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.1.9(@swc/core@1.10.18(@swc/helpers@0.5.5))(encoding@0.1.13)(typescript@5.7.3)
+      '@lerna/create': 8.1.9(@swc/core@1.10.18(@swc/helpers@0.5.5))(encoding@0.1.13)(typescript@5.8.2)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
@@ -28021,7 +28108,7 @@ snapshots:
       conventional-changelog-angular: 7.0.0
       conventional-changelog-core: 5.0.1
       conventional-recommended-bump: 7.0.1
-      cosmiconfig: 9.0.0(typescript@5.7.3)
+      cosmiconfig: 9.0.0(typescript@5.8.2)
       dedent: 1.5.3
       envinfo: 7.13.0
       execa: 5.0.0
@@ -28074,7 +28161,7 @@ snapshots:
       strong-log-transformer: 2.1.0
       tar: 6.2.1
       temp-dir: 1.0.0
-      typescript: 5.7.3
+      typescript: 5.8.2
       upath: 2.0.1
       uuid: 10.0.0
       validate-npm-package-license: 3.0.4
@@ -29091,7 +29178,7 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  ox@0.6.7(typescript@5.7.2)(zod@3.24.2):
+  ox@0.6.9(typescript@5.7.2)(zod@3.24.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.8.1
@@ -29105,7 +29192,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.7.3)(zod@3.24.2):
+  ox@0.6.9(typescript@5.7.3)(zod@3.24.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.8.1
@@ -30622,6 +30709,8 @@ snapshots:
 
   std-env@3.8.0: {}
 
+  std-env@3.8.1: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -30827,8 +30916,8 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 4.2.19
-      svelte-preprocess: 5.1.4(@babel/core@7.26.9)(postcss-load-config@4.0.2(postcss@8.5.3))(postcss@8.5.3)(svelte@4.2.19)(typescript@5.7.2)
-      typescript: 5.7.2
+      svelte-preprocess: 5.1.4(@babel/core@7.26.9)(postcss-load-config@4.0.2(postcss@8.5.3))(postcss@8.5.3)(svelte@4.2.19)(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -30844,7 +30933,7 @@ snapshots:
     dependencies:
       svelte: 4.2.19
 
-  svelte-preprocess@5.1.4(@babel/core@7.26.9)(postcss-load-config@4.0.2(postcss@8.5.3))(postcss@8.5.3)(svelte@4.2.19)(typescript@5.7.2):
+  svelte-preprocess@5.1.4(@babel/core@7.26.9)(postcss-load-config@4.0.2(postcss@8.5.3))(postcss@8.5.3)(svelte@4.2.19)(typescript@5.7.3):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
@@ -30856,7 +30945,7 @@ snapshots:
       '@babel/core': 7.26.9
       postcss: 8.5.3
       postcss-load-config: 4.0.2(postcss@8.5.3)
-      typescript: 5.7.2
+      typescript: 5.7.3
 
   svelte@4.2.19:
     dependencies:
@@ -31068,7 +31157,7 @@ snapshots:
 
   tinyglobby@0.2.10:
     dependencies:
-      fdir: 6.4.2(picomatch@4.0.2)
+      fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
 
   tinyglobby@0.2.12:
@@ -31214,7 +31303,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.3.5(@swc/core@1.10.18(@swc/helpers@0.5.5))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0):
+  tsup@8.3.5(@swc/core@1.10.18(@swc/helpers@0.5.5))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.2)(typescript@5.8.2)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.24.2)
       cac: 6.7.14
@@ -31235,7 +31324,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.10.18(@swc/helpers@0.5.5)
       postcss: 8.5.3
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -31404,21 +31493,21 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typedoc-plugin-coverage@3.4.1(typedoc@0.26.11(typescript@5.7.3)):
+  typedoc-plugin-coverage@3.4.1(typedoc@0.26.11(typescript@5.8.2)):
     dependencies:
-      typedoc: 0.26.11(typescript@5.7.3)
+      typedoc: 0.26.11(typescript@5.8.2)
 
-  typedoc-plugin-missing-exports@3.1.0(typedoc@0.26.11(typescript@5.7.3)):
+  typedoc-plugin-missing-exports@3.1.0(typedoc@0.26.11(typescript@5.8.2)):
     dependencies:
-      typedoc: 0.26.11(typescript@5.7.3)
+      typedoc: 0.26.11(typescript@5.8.2)
 
-  typedoc@0.26.11(typescript@5.7.3):
+  typedoc@0.26.11(typescript@5.8.2):
     dependencies:
       lunr: 2.3.9
       markdown-it: 14.1.0
       minimatch: 9.0.5
       shiki: 1.27.0
-      typescript: 5.7.3
+      typescript: 5.8.2
       yaml: 2.7.0
 
   typescript-eslint@8.18.2(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3):
@@ -31456,6 +31545,8 @@ snapshots:
   typescript@5.7.2: {}
 
   typescript@5.7.3: {}
+
+  typescript@5.8.2: {}
 
   ua-parser-js@1.0.40: {}
 
@@ -31705,16 +31796,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.23.7(typescript@5.7.2)(zod@3.24.2):
+  viem@2.23.10(typescript@5.7.2)(zod@3.24.2):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.7.2)(zod@3.24.2)
-      isows: 1.0.6(ws@8.18.0)
-      ox: 0.6.7(typescript@5.7.2)(zod@3.24.2)
-      ws: 8.18.0
+      isows: 1.0.6(ws@8.18.1)
+      ox: 0.6.9(typescript@5.7.2)(zod@3.24.2)
+      ws: 8.18.1
     optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -31722,16 +31813,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.23.7(typescript@5.7.3)(zod@3.24.2):
+  viem@2.23.10(typescript@5.7.3)(zod@3.24.2):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.7.3)(zod@3.24.2)
-      isows: 1.0.6(ws@8.18.0)
-      ox: 0.6.7(typescript@5.7.3)(zod@3.24.2)
-      ws: 8.18.0
+      isows: 1.0.6(ws@8.18.1)
+      ox: 0.6.9(typescript@5.7.3)(zod@3.24.2)
+      ws: 8.18.1
     optionalDependencies:
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -32503,7 +32594,7 @@ snapshots:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.17.1)
       '@babel/core': 7.26.9
       '@babel/preset-env': 7.26.9(@babel/core@7.26.9)
-      '@babel/runtime': 7.26.9
+      '@babel/runtime': 7.26.10
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.26.9)(@types/babel__core@7.20.5)(rollup@2.79.2)
       '@rollup/plugin-node-resolve': 15.3.1(rollup@2.79.2)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.2)
@@ -32662,6 +32753,8 @@ snapshots:
   ws@8.13.0: {}
 
   ws@8.18.0: {}
+
+  ws@8.18.1: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a React hook for retrieving predeployed accounts, enhancing how account data is accessed.
  - Improved React integration with updated exports for better compatibility.

- **Refactor**
  - Streamlined several components to replace manual state handling with the new hook, simplifying account management.

- **Chore**
  - Optimized dependency management and build configurations, including adjustments to development dependency categorization and ignore settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->