### PR TITLE
feat: reset zustand store

### DIFF
--- a/packages/sdk/src/__tests__/state.test.ts
+++ b/packages/sdk/src/__tests__/state.test.ts
@@ -109,6 +109,8 @@ describe("createDojoStore", () => {
         expect(state.entities["game1"]).toEqual(initialGame);
         expect(state.entities["item1"]).toEqual(initialItem);
         expect(state.entities["galaxy1"]).toEqual(initialGalaxy);
+        state.resetStore();
+        expect(state.getEntities()).toHaveLength(0);
     });
 
     test("mergeEntities should merge entities to the store", () => {

--- a/packages/sdk/src/state/index.ts
+++ b/packages/sdk/src/state/index.ts
@@ -40,6 +40,7 @@ export interface GameState<T extends SchemaType> {
         namespace: keyof T,
         model: keyof T[keyof T]
     ) => ParsedEntity<T>[];
+    resetStore: () => void;
 }
 
 // Define the store type

--- a/packages/sdk/src/state/zustand.ts
+++ b/packages/sdk/src/state/zustand.ts
@@ -386,6 +386,12 @@ export function createDojoStoreFactory<T extends SchemaType>(
                         return !!entity.models[namespace]?.[model];
                     });
                 },
+                resetStore: () => {
+                    set((state: Draft<GameState<T>>) => {
+                        state.entities = {};
+                        state.pendingTransactions = {};
+                    });
+                },
             }))
         )
     );


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a method to reset the store, clearing all entities and pending transactions.

- **Tests**
  - Updated tests to verify that the store is properly cleared after resetting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->