### PR TITLE
fix: pagination missing next_cursor

### DIFF
--- a/.changeset/many-kings-count.md
+++ b/.changeset/many-kings-count.md
@@ -1,0 +1,15 @@
+---
+"@dojoengine/sdk": patch
+"@dojoengine/core": patch
+"@dojoengine/create-burner": patch
+"@dojoengine/create-dojo": patch
+"@dojoengine/predeployed-connector": patch
+"@dojoengine/react": patch
+"@dojoengine/state": patch
+"@dojoengine/torii-client": patch
+"@dojoengine/torii-wasm": patch
+"@dojoengine/utils": patch
+"@dojoengine/utils-wasm": patch
+---
+
+fix: pagination missing next_cursor

--- a/packages/sdk/src/__tests__/pagination.test.ts
+++ b/packages/sdk/src/__tests__/pagination.test.ts
@@ -31,9 +31,9 @@ describe("Pagination", () => {
         const pagination = Pagination.fromQuery<
             typeof schema,
             (typeof schema)[]
-        >(query);
+        >(query, "next-cursor");
         expect(pagination.limit).toBe(20);
-        expect(pagination.cursor).toBe("test-cursor");
+        expect(pagination.cursor).toBe("next-cursor");
     });
 
     it("should set items and return the instance", () => {

--- a/packages/sdk/src/internal/pagination.ts
+++ b/packages/sdk/src/internal/pagination.ts
@@ -36,12 +36,13 @@ export class Pagination<T extends SchemaType, Inner extends any[]> {
      * @returns A new Pagination instance configured with the query's pagination settings
      */
     static fromQuery<T extends SchemaType, Inner extends any[]>(
-        query: ToriiQueryBuilder<T>
+        query: ToriiQueryBuilder<T>,
+        nextCursor?: string
     ): Pagination<T, Inner> {
         const pagination = query.getPagination();
         return new Pagination(
             pagination.limit,
-            pagination.cursor,
+            nextCursor,
             pagination.direction
         );
     }

--- a/packages/sdk/src/node/index.ts
+++ b/packages/sdk/src/node/index.ts
@@ -62,7 +62,9 @@ export async function init<T extends SchemaType>(
             const entities = await client.getEntities(q);
             const parsedEntities = parseEntities<T>(entities.items);
             return [
-                Pagination.fromQuery(query).withItems(parsedEntities),
+                Pagination.fromQuery(query, entities.next_cursor).withItems(
+                    parsedEntities
+                ),
                 client.onEntityUpdated(
                     q.clause,
                     subscribeQueryModelCallback(callback)
@@ -84,7 +86,9 @@ export async function init<T extends SchemaType>(
             const entities = await client.getEventMessages(q);
             const parsedEntities = parseEntities<T>(entities.items);
             return [
-                Pagination.fromQuery(query).withItems(parsedEntities),
+                Pagination.fromQuery(query, entities.next_cursor).withItems(
+                    parsedEntities
+                ),
                 client.onEventMessageUpdated(
                     q.clause,
                     subscribeQueryModelCallback(callback)
@@ -115,7 +119,7 @@ export async function init<T extends SchemaType>(
 
             const entities = await client.getEntities(q);
 
-            return Pagination.fromQuery(query).withItems(
+            return Pagination.fromQuery(query, entities.next_cursor).withItems(
                 parseEntities(entities.items)
             );
         },
@@ -132,7 +136,7 @@ export async function init<T extends SchemaType>(
 
             const entities = await client.getEventMessages(q);
 
-            return Pagination.fromQuery(query).withItems(
+            return Pagination.fromQuery(query, entities.next_cursor).withItems(
                 parseEntities(entities.items)
             );
         },

--- a/packages/sdk/src/web/index.ts
+++ b/packages/sdk/src/web/index.ts
@@ -81,7 +81,9 @@ export async function init<T extends SchemaType>(
             const entities = await client.getEntities(q);
             const parsedEntities = parseEntities<T>(entities.items);
             return [
-                Pagination.fromQuery(query).withItems(parsedEntities),
+                Pagination.fromQuery(query, entities.next_cursor).withItems(
+                    parsedEntities
+                ),
                 client.onEntityUpdated(
                     q.clause,
                     subscribeQueryModelCallback(callback)
@@ -103,7 +105,9 @@ export async function init<T extends SchemaType>(
             const entities = await client.getEventMessages(q);
             const parsedEntities = parseEntities<T>(entities.items);
             return [
-                Pagination.fromQuery(query).withItems(parsedEntities),
+                Pagination.fromQuery(query, entities.next_cursor).withItems(
+                    parsedEntities
+                ),
                 client.onEventMessageUpdated(
                     q.clause,
                     subscribeQueryModelCallback(callback)
@@ -134,7 +138,7 @@ export async function init<T extends SchemaType>(
 
             const entities = await client.getEntities(q);
 
-            return Pagination.fromQuery(query).withItems(
+            return Pagination.fromQuery(query, entities.next_cursor).withItems(
                 parseEntities(entities.items)
             );
         },
@@ -151,7 +155,7 @@ export async function init<T extends SchemaType>(
 
             const entities = await client.getEventMessages(q);
 
-            return Pagination.fromQuery(query).withItems(
+            return Pagination.fromQuery(query, entities.next_cursor).withItems(
                 parseEntities(entities.items)
             );
         },

--- a/packages/sdk/src/web/react/hooks/hooks.ts
+++ b/packages/sdk/src/web/react/hooks/hooks.ts
@@ -15,7 +15,7 @@ import { deepEqual, sleep } from "./utils";
  */
 export function createSubscriptionHook<
     Schema extends SchemaType,
-    Historical extends boolean = false,
+    Historical extends boolean = false
 >(config: {
     subscribeMethod: (
         options: SubscribeParams<Schema>


### PR DESCRIPTION
Closes #438 

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue where the pagination response was missing the next cursor, ensuring smoother and more accurate paginated data retrieval across various features.

- **Tests**
	- Updated pagination tests to verify correct handling of the next cursor in paginated responses.

- **Style**
	- Minor formatting adjustment in a hook function signature (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->