### PR TITLE
fix: remove _hashedKey from subscription callback

### DIFF
--- a/.changeset/beige-ends-shave.md
+++ b/.changeset/beige-ends-shave.md
@@ -1,0 +1,15 @@
+---
+"@dojoengine/sdk": patch
+"@dojoengine/core": patch
+"@dojoengine/create-burner": patch
+"@dojoengine/create-dojo": patch
+"@dojoengine/predeployed-connector": patch
+"@dojoengine/react": patch
+"@dojoengine/state": patch
+"@dojoengine/torii-client": patch
+"@dojoengine/torii-wasm": patch
+"@dojoengine/utils": patch
+"@dojoengine/utils-wasm": patch
+---
+
+fix: removed \_hashedKey from subscription callback

--- a/packages/sdk/src/internal/subscribeQueryModel.ts
+++ b/packages/sdk/src/internal/subscribeQueryModel.ts
@@ -17,7 +17,7 @@ import type {
 export function subscribeQueryModelCallback<T extends SchemaType>(
     callback: SubscriptionCallback<StandardizedQueryResult<T>>
 ) {
-    return (_hashedKey: string, entityData: Entity) => {
+    return (entityData: Entity) => {
         try {
             if (callback) {
                 const parsedData = parseEntities<T>([entityData]);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified subscription callback functions by removing an internal parameter, resulting in a cleaner callback signature for improved usability. No changes to user-facing features or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->