### PR TITLE
chore: bump dojo.c to get latest publishMessage endpoint

### DIFF
--- a/.changeset/wild-trees-admire.md
+++ b/.changeset/wild-trees-admire.md
@@ -1,0 +1,15 @@
+---
+"@dojoengine/torii-wasm": patch
+"@dojoengine/core": patch
+"@dojoengine/sdk": patch
+"@dojoengine/create-burner": patch
+"@dojoengine/create-dojo": patch
+"@dojoengine/predeployed-connector": patch
+"@dojoengine/react": patch
+"@dojoengine/state": patch
+"@dojoengine/torii-client": patch
+"@dojoengine/utils": patch
+"@dojoengine/utils-wasm": patch
+---
+
+chore: bump dojo.c to get latest publishMessage endpoint

--- a/examples/example-node-worker/main.ts
+++ b/examples/example-node-worker/main.ts
@@ -27,7 +27,6 @@ global.WorkerGlobalScope = global;
 const sdk = await init({
     client: {
         toriiUrl: dojoConfig.toriiUrl,
-        relayUrl: "/ip4/127.0.0.1/tcp/9092/ws",
         worldAddress: dojoConfig.manifest.world.address,
     },
     domain: {

--- a/examples/example-vanillajs-phaser-recs/src/dojo/setup.ts
+++ b/examples/example-vanillajs-phaser-recs/src/dojo/setup.ts
@@ -24,7 +24,6 @@ export async function setup({ ...config }: Config) {
     try {
         toriiClient = await torii.createClient({
             toriiUrl: config.toriiUrl,
-            relayUrl: "",
             worldAddress: config.manifest.world.address || "",
         });
     } catch (e) {

--- a/examples/example-vite-experimental-sdk/src/main.ts
+++ b/examples/example-vite-experimental-sdk/src/main.ts
@@ -13,7 +13,6 @@ async function main() {
     const sdk = await init({
         client: {
             toriiUrl: dojoConfig.toriiUrl,
-            relayUrl: dojoConfig.relayUrl,
             worldAddress: dojoConfig.manifest.world.address,
         },
         domain: {

--- a/examples/example-vite-grpc-playground/src/main.tsx
+++ b/examples/example-vite-grpc-playground/src/main.tsx
@@ -9,7 +9,6 @@ async function main() {
     const sdk = await init({
         client: {
             toriiUrl: dojoConfig.toriiUrl,
-            relayUrl: dojoConfig.relayUrl,
             worldAddress: dojoConfig.manifest.world.address,
         },
         domain: {

--- a/examples/example-vite-kitchen-sink/src/main.tsx
+++ b/examples/example-vite-kitchen-sink/src/main.tsx
@@ -18,7 +18,6 @@ async function main() {
     const sdk = await init<SchemaType>({
         client: {
             toriiUrl: env.VITE_TORII_URL,
-            relayUrl: env.VITE_RELAY_URL,
             worldAddress: dojoConfig.manifest.world.address,
         },
         domain: {

--- a/examples/example-vite-phaser-sdk/src/main.ts
+++ b/examples/example-vite-phaser-sdk/src/main.ts
@@ -38,7 +38,6 @@ async function main() {
     const sdk = await init<SchemaType>({
         client: {
             toriiUrl: dojoConfig.toriiUrl,
-            relayUrl: dojoConfig.relayUrl,
             worldAddress: dojoConfig.manifest.world.address,
         },
         domain: {

--- a/examples/example-vite-react-app-recs/src/dojo/setup.ts
+++ b/examples/example-vite-react-app-recs/src/dojo/setup.ts
@@ -18,7 +18,6 @@ export async function setup({ ...config }: DojoConfig) {
     // Initialize Torii client for interacting with the Dojo network
     const toriiClient = new torii.ToriiClient({
         toriiUrl: config.toriiUrl,
-        relayUrl: "",
         worldAddress: config.manifest.world.address || "",
     });
 

--- a/examples/example-vite-react-phaser-recs/src/dojo/generated/setup.ts
+++ b/examples/example-vite-react-phaser-recs/src/dojo/generated/setup.ts
@@ -15,7 +15,6 @@ export async function setup({ ...config }: DojoConfig) {
     // torii client
     const toriiClient = new torii.ToriiClient({
         toriiUrl: config.toriiUrl,
-        relayUrl: config.relayUrl,
         worldAddress: config.manifest.world.address || "",
     });
 

--- a/examples/example-vite-react-pwa-recs/src/dojo/generated/setup.ts
+++ b/examples/example-vite-react-pwa-recs/src/dojo/generated/setup.ts
@@ -17,7 +17,6 @@ export async function setup({ ...config }: DojoConfig) {
     // torii client
     const toriiClient = new torii.ToriiClient({
         toriiUrl: config.toriiUrl,
-        relayUrl: config.relayUrl,
         worldAddress: config.manifest.world.address || "",
     });
 

--- a/examples/example-vite-react-sql/src/main.tsx
+++ b/examples/example-vite-react-sql/src/main.tsx
@@ -34,7 +34,6 @@ async function main() {
     const sdk = await init<SchemaType>({
         client: {
             toriiUrl: dojoConfig.toriiUrl,
-            relayUrl: dojoConfig.relayUrl,
             worldAddress: dojoConfig.manifest.world.address,
         },
         domain: {

--- a/examples/example-vite-react-threejs-recs/src/dojo/generated/setup.ts
+++ b/examples/example-vite-react-threejs-recs/src/dojo/generated/setup.ts
@@ -17,7 +17,6 @@ export async function setup({ ...config }: DojoConfig) {
     // torii client
     const toriiClient = new torii.ToriiClient({
         toriiUrl: config.toriiUrl,
-        relayUrl: config.relayUrl,
         worldAddress: config.manifest.world.address || "",
     });
 

--- a/examples/example-vite-svelte-recs/src/dojo/setup.ts
+++ b/examples/example-vite-svelte-recs/src/dojo/setup.ts
@@ -16,7 +16,6 @@ export async function setup({ ...config }: DojoConfig) {
     // torii client
     const toriiClient = await torii.createClient({
         toriiUrl: config.toriiUrl,
-        relayUrl: "",
         worldAddress: config.manifest.world.address || "",
     });
 

--- a/examples/example-vue-app-recs/src/dojo/generated/setup.ts
+++ b/examples/example-vue-app-recs/src/dojo/generated/setup.ts
@@ -16,7 +16,6 @@ export async function setup({ ...config }: DojoConfig) {
     // torii client
     const toriiClient = new torii.ToriiClient({
         toriiUrl: config.toriiUrl,
-        relayUrl: "",
         worldAddress: config.manifest.world.address || "",
     });
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -4,7 +4,6 @@ import {
     KATANA_PREFUNDED_ADDRESS,
     KATANA_PREFUNDED_PRIVATE_KEY,
     LOCAL_KATANA,
-    LOCAL_RELAY,
     LOCAL_TORII,
 } from "../constants";
 
@@ -13,7 +12,6 @@ export type DojoConfig = ReturnType<typeof createDojoConfig>;
 interface DojoConfigParams {
     rpcUrl?: string;
     toriiUrl?: string;
-    relayUrl?: string;
     masterAddress?: string;
     masterPrivateKey?: string;
     accountClassHash?: string;
@@ -28,7 +26,6 @@ export function createDojoConfig({ manifest, ...config }: DojoConfigParams) {
     return {
         rpcUrl: config.rpcUrl ?? LOCAL_KATANA,
         toriiUrl: config.toriiUrl ?? LOCAL_TORII,
-        relayUrl: config.relayUrl ?? LOCAL_RELAY,
         masterAddress: config.masterAddress ?? KATANA_PREFUNDED_ADDRESS,
         masterPrivateKey:
             config.masterPrivateKey ?? KATANA_PREFUNDED_PRIVATE_KEY,

--- a/packages/sdk/src/__example__/index.ts
+++ b/packages/sdk/src/__example__/index.ts
@@ -73,7 +73,6 @@ async function exampleUsage() {
     const db = await init<MockSchemaType>({
         client: {
             toriiUrl: "your-torii-url",
-            relayUrl: "your-relay-url",
             worldAddress: "your-world-address",
         },
         domain: {

--- a/packages/sdk/src/__tests__/generateTypedData.test.ts
+++ b/packages/sdk/src/__tests__/generateTypedData.test.ts
@@ -18,7 +18,6 @@ describe("generateTypedData", () => {
     const mockConfig = {
         client: {
             toriiUrl: "http://localhost:8080",
-            relayUrl: "/ip4/127.0.0.1/tcp/9090",
             worldAddress: "0x123",
         },
         domain: {

--- a/packages/sdk/src/internal/types.ts
+++ b/packages/sdk/src/internal/types.ts
@@ -378,7 +378,7 @@ export interface SDK<T extends SchemaType> {
     sendMessage: (
         data: TypedData,
         account?: Account
-    ) => Promise<Result<Uint8Array, string>>;
+    ) => Promise<Result<string, string>>;
 
     /**
      * @param {string[]} contract_addresses

--- a/packages/sdk/src/node/index.ts
+++ b/packages/sdk/src/node/index.ts
@@ -39,7 +39,6 @@ export * from "../internal/models.ts";
 
 export const defaultClientConfig: Partial<torii.ClientConfig> = {
     toriiUrl: "http://localhost:8080",
-    relayUrl: "/ip4/127.0.0.1/tcp/9090",
 };
 
 export async function init<T extends SchemaType>(
@@ -193,7 +192,7 @@ export async function init<T extends SchemaType>(
         sendMessage: async (
             data: TypedData,
             _account?: Account
-        ): Promise<Result<Uint8Array, string>> => {
+        ): Promise<Result<string, string>> => {
             if (!options.signer) {
                 return err(NO_SIGNER);
             }

--- a/packages/sdk/src/web/index.ts
+++ b/packages/sdk/src/web/index.ts
@@ -52,7 +52,6 @@ export async function createClient(
 
 export const defaultClientConfig: Partial<torii.ClientConfig> = {
     toriiUrl: "http://localhost:8080",
-    relayUrl: "/ip4/127.0.0.1/tcp/9090",
 };
 
 /**
@@ -212,7 +211,7 @@ export async function init<T extends SchemaType>(
         sendMessage: async (
             data: TypedData,
             account?: Account
-        ): Promise<Result<Uint8Array, string>> => {
+        ): Promise<Result<string, string>> => {
             if (!account) {
                 return err(NO_ACCOUNT);
             }

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,6 @@ const db =
         // your config
         client: {
             toriiUrl: dojoConfig.toriiUrl,
-            relayUrl: dojoConfig.relayUrl,
             worldAddress: dojoConfig.manifest.world.address,
         },
         // allows typed messaging via indexer
@@ -195,18 +194,19 @@ Before running examples, you need to build the packages:
     ```bash
     pnpm run dev
     ```
-- Try out a specific example : 
+
+- Try out a specific example :
 
     ```bash
     pnpm run dev --filter example-vite-react-sdk
     ```
-    
 
 ### Running The Examples
 
 To run the examples, you'll need to set up three terminal windows:
 
-**With docker**: 
+**With docker**:
+
 1. Navigate to the Dojo starter directory:
 
     ```bash


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the `relayUrl` property from all client configuration options across SDKs, examples, and documentation.
  - Updated the expected result type of the `sendMessage` method to return a string instead of a byte array.

- **Documentation**
  - Updated usage examples and documentation to reflect the removal of the `relayUrl` property and improved formatting.

- **Chores**
  - Synchronized package versions to incorporate the latest updates and endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->