### PR TITLE
feat: pulling types from typescript abi

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
         "lint": "biome lint . --write",
         "test": "vitest run --passWithNoTests --coverage",
         "docs": "typedoc",
-    "type:check": "tsc"
+        "type:check": "tsc"
     },
     "exports": {
         ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,10 @@
     "license": "MIT",
     "main": "./dist/index.js",
     "type": "module",
+    "bin": {
+        "compile-abi": "./dist/cli/compile-abi.js",
+        "generate-abi-types": "./dist/cli/generate-abi-types.js"
+    },
     "scripts": {
         "build:deps": "tsup",
         "build": "pnpm build:deps",
@@ -14,7 +18,8 @@
         "lint:check": "biome lint .",
         "lint": "biome lint . --write",
         "test": "vitest run --passWithNoTests --coverage",
-        "docs": "typedoc"
+        "docs": "typedoc",
+    "type:check": "tsc"
     },
     "exports": {
         ".": {

--- a/packages/core/src/cli/compile-abi.ts
+++ b/packages/core/src/cli/compile-abi.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "fs";
+import { join } from "path";
+
+type AbiEntry = {
+    [key: string]: any;
+};
+
+type ManifestContract = {
+    abi?: AbiEntry[];
+    [key: string]: any;
+};
+
+type Manifest = {
+    world?: {
+        abi?: AbiEntry[];
+        [key: string]: any;
+    };
+    contracts?: ManifestContract[];
+    [key: string]: any;
+};
+
+type TargetFile = {
+    abi?: AbiEntry[];
+    [key: string]: any;
+};
+
+function collectAbis(): void {
+    const dojoRoot = process.env.DOJO_ROOT || process.cwd();
+    const dojoEnv = process.env.DOJO_ENV || "dev";
+
+    const manifestPath = join(dojoRoot, `manifest_${dojoEnv}.json`);
+    const targetDir = join(dojoRoot, "target", dojoEnv);
+
+    const allAbis: AbiEntry[] = [];
+
+    // Read manifest file
+    if (existsSync(manifestPath)) {
+        try {
+            const manifestContent = readFileSync(manifestPath, "utf-8");
+            const manifest: Manifest = JSON.parse(manifestContent);
+
+            // Extract ABIs from world
+            if (manifest.world?.abi) {
+                allAbis.push(...manifest.world.abi);
+            }
+
+            // Extract ABIs from contracts
+            if (manifest.contracts) {
+                for (const contract of manifest.contracts) {
+                    if (contract.abi) {
+                        allAbis.push(...contract.abi);
+                    }
+                }
+            }
+        } catch (error) {
+            console.error(`Error reading manifest file: ${error}`);
+            process.exit(1);
+        }
+    } else {
+        console.error(`Manifest file not found: ${manifestPath}`);
+        process.exit(1);
+    }
+
+    // Read target directory files
+    if (existsSync(targetDir)) {
+        try {
+            const files = readdirSync(targetDir).filter((file) =>
+                file.endsWith(".json")
+            );
+
+            for (const file of files) {
+                const filePath = join(targetDir, file);
+                try {
+                    const fileContent = readFileSync(filePath, "utf-8");
+                    const targetFile: TargetFile = JSON.parse(fileContent);
+
+                    // Extract only the abi key
+                    if (targetFile.abi) {
+                        allAbis.push(...targetFile.abi);
+                    }
+                } catch (error) {
+                    console.error(`Error reading file ${file}: ${error}`);
+                }
+            }
+        } catch (error) {
+            console.error(`Error reading target directory: ${error}`);
+        }
+    } else {
+        console.warn(`Target directory not found: ${targetDir}`);
+    }
+
+    // Write output
+    const output = {
+        abi: allAbis,
+    };
+
+    const outputPath = join(dojoRoot, "compiled-abi.json");
+    writeFileSync(outputPath, JSON.stringify(output, null, 2));
+
+    console.log(`✅ ABI compilation complete!`);
+    console.log(`📄 Output written to: ${outputPath}`);
+    console.log(`📊 Total ABI entries: ${allAbis.length}`);
+}
+
+// Run the compilation
+try {
+    collectAbis();
+} catch (error) {
+    console.error(`Unexpected error: ${error}`);
+    process.exit(1);
+}

--- a/packages/core/src/cli/generate-abi-types.ts
+++ b/packages/core/src/cli/generate-abi-types.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Generate a TypeScript file from compiled-abi.json with proper const assertions
+ * This allows TypeScript to extract literal types from the ABI
+ */
+function generateAbiTypes(): void {
+    const inputPath = join(process.cwd(), "compiled-abi.json");
+    const outputPath = join(process.cwd(), "compiled-abi.ts");
+
+    try {
+        // Read the compiled ABI
+        const abiContent = readFileSync(inputPath, "utf-8");
+        const abiJson = JSON.parse(abiContent);
+
+        // Generate TypeScript content
+        const tsContent = `// This file is auto-generated from compiled-abi.json
+// Do not edit manually
+
+export const compiledAbi = ${JSON.stringify(abiJson, null, 2)} as const;
+
+export type CompiledAbi = typeof compiledAbi;
+`;
+
+        // Write the TypeScript file
+        writeFileSync(outputPath, tsContent);
+
+        console.log(`✅ Generated TypeScript types!`);
+        console.log(`📄 Output written to: ${outputPath}`);
+        console.log(`\nUsage in your code:`);
+        console.log(`\nimport { compiledAbi } from './compiled-abi';`);
+        console.log(`import { ExtractAbiTypes } from '@dojoengine/core';`);
+        console.log(`\ntype MyAbi = ExtractAbiTypes<typeof compiledAbi>;`);
+        console.log(
+            `type Position = MyAbi["structs"]["dojo_starter::models::Position"];`
+        );
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        process.exit(1);
+    }
+}
+
+// Run the generation
+generateAbiTypes();

--- a/packages/core/src/types/README.md
+++ b/packages/core/src/types/README.md
@@ -1,0 +1,115 @@
+# Dynamic Type System for Dojo Manifests
+
+This module provides a powerful TypeScript type system that dynamically extracts types from Dojo manifest files, providing full type safety when working with contracts, models, and events.
+
+## Features
+
+- **Automatic Type Extraction**: Extracts types from manifest JSON files
+- **Cairo to TypeScript Mapping**: Automatically converts Cairo types to TypeScript equivalents
+- **Full ABI Support**: Extracts structs, enums, functions, and events from ABIs
+- **Type-Safe Contract Calls**: Get typed function inputs and outputs
+- **Model Type Generation**: Generate TypeScript interfaces for your Dojo models
+
+## Usage
+
+### Basic Setup
+
+```typescript
+import { ExtractManifestTypes } from "@dojoengine/core";
+import manifest from "./manifest_dev.json";
+
+// Extract all types from the manifest
+type MyTypes = ExtractManifestTypes<typeof manifest>;
+```
+
+### Working with Contracts
+
+```typescript
+// Access contract types
+type Contracts = MyTypes["contracts"];
+type ActionsContract = Contracts["dojo_starter-actions"];
+
+// Get function types
+type MoveFunction = ActionsContract["abi"]["functions"]["move"];
+type MoveInputs = MoveFunction["inputs"]; // { direction: Direction }
+type MoveOutput = MoveFunction["outputs"]; // void
+
+// Use in your code
+function callMove(inputs: MoveInputs): MoveOutput {
+    // Type-safe contract call
+}
+```
+
+### Working with Models
+
+```typescript
+// Access model types
+type Models = MyTypes["models"];
+type Position = Models["dojo_starter-Position"];
+type PositionFields = Position["fields"];
+
+// Or use the helper
+import { GetModel } from "@dojoengine/core";
+type PositionData = GetModel<typeof manifest, "dojo_starter-Position">;
+```
+
+### Working with Events
+
+```typescript
+// Access event types
+type Events = MyTypes["events"];
+type MovedEvent = Events["dojo_starter-Moved"];
+type MovedEventData = MovedEvent["data"];
+
+// Type-safe event handler
+function handleMoved(data: MovedEventData) {
+    // Handle event with typed data
+}
+```
+
+## Type Mappings
+
+The system automatically maps Cairo types to TypeScript:
+
+| Cairo Type                                          | TypeScript Type |
+| --------------------------------------------------- | --------------- |
+| `core::felt252`                                     | `string`        |
+| `core::integer::u8`                                 | `number`        |
+| `core::integer::u16`                                | `number`        |
+| `core::integer::u32`                                | `number`        |
+| `core::integer::u64`                                | `bigint`        |
+| `core::integer::u128`                               | `bigint`        |
+| `core::bool`                                        | `boolean`       |
+| `core::starknet::contract_address::ContractAddress` | `string`        |
+| `core::byte_array::ByteArray`                       | `string`        |
+| `core::array::Array<T>`                             | `T[]`           |
+| `core::array::Span<T>`                              | `T[]`           |
+
+## Advanced Usage
+
+### Extract Specific Function Type
+
+```typescript
+import { GetContractFunction } from "@dojoengine/core";
+
+type SpawnFunction = GetContractFunction<
+    typeof manifest,
+    "dojo_starter-actions",
+    "spawn"
+>;
+```
+
+### Working with Enums
+
+```typescript
+// Access enum types from ABI
+type Direction =
+    ActionsContract["abi"]["enums"]["dojo_starter::models::Direction"];
+
+// Use in your code
+const direction: Direction = { Left: {} };
+```
+
+## Example
+
+See `example-usage.ts` for a complete example of using the type system with a real manifest file.

--- a/packages/core/src/types/example-usage.ts
+++ b/packages/core/src/types/example-usage.ts
@@ -1,10 +1,10 @@
 import { ExtractAbiTypes } from "./index";
 
-// Problem: Importing JSON directly doesn't preserve literal types in TypeScript
-import compiledJson from "../../../../worlds/dojo-starter/compiled-abi.json";
-
 // Solution 1: Import the generated TypeScript file instead
-import { compiledAbi } from "../../../../worlds/dojo-starter/compiled-abi";
+import {
+    CompiledAbi,
+    compiledAbi,
+} from "../../../../worlds/dojo-starter/compiled-abi";
 
 // Extract ABI types from the TypeScript version (this works!)
 type MyAbi = ExtractAbiTypes<typeof compiledAbi>;
@@ -31,8 +31,12 @@ type MyAbiFunctions = MyAbi["functions"];
 type MyAbiInterfaces = MyAbi["interfaces"];
 
 // Now you can use the extracted types
-type Position = MyAbi["structs"]["dojo_starter::models::Position"]; // { player: string; vec: Vec2 }
 type Vec2 = MyAbi["structs"]["dojo_starter::models::Vec2"]; // { x: number; y: number }
+type Position = MyAbi["structs"]["dojo_starter::models::Position"]; // { player: string; vec: Vec2 }
+type PositionCount = MyAbi["structs"]["dojo_starter::models::PositionCount"];
+
+// Note: Nested struct references are resolved through the ABI context.
+// The type system now supports cross-references between structs in the same ABI.
 
 // Enum types now include variants structure
 type Direction = MyAbi["enums"]["dojo_starter::models::Direction"];

--- a/packages/core/src/types/example-usage.ts
+++ b/packages/core/src/types/example-usage.ts
@@ -1,67 +1,57 @@
 import { ExtractAbiTypes } from "./index";
 
-// There are two approaches to use compiled ABI with TypeScript:
-
-// Approach 1: Import the JSON and use it at runtime (but types won't work automatically)
+// Problem: Importing JSON directly doesn't preserve literal types in TypeScript
 import compiledJson from "../../../../worlds/dojo-starter/compiled-abi.json";
 
-// Approach 2: Use a code generation tool to create a TypeScript file from the JSON
-// For example, create a compiled-abi.ts file that exports:
-// export const compiledAbi = { abi: [...] } as const;
+// Solution 1: Import the generated TypeScript file instead
+import { compiledAbi } from "../../../../worlds/dojo-starter/compiled-abi";
 
-// For this example, we'll show how it would work with proper typing:
-// You would need to generate this from your compiled-abi.json
-declare const compiledAbi: {
-    readonly abi: readonly [
-        {
-            readonly type: "struct";
-            readonly name: "dojo_starter::models::Position";
-            readonly members: readonly [
-                {
-                    readonly name: "player";
-                    readonly type: "core::starknet::contract_address::ContractAddress";
-                },
-                {
-                    readonly name: "vec";
-                    readonly type: "dojo_starter::models::Vec2";
-                },
-            ];
-        },
-        {
-            readonly type: "struct";
-            readonly name: "dojo_starter::models::Vec2";
-            readonly members: readonly [
-                { readonly name: "x"; readonly type: "core::integer::u32" },
-                { readonly name: "y"; readonly type: "core::integer::u32" },
-            ];
-        },
-        {
-            readonly type: "enum";
-            readonly name: "dojo_starter::models::Direction";
-            readonly variants: readonly [
-                { readonly name: "None"; readonly type: "()" },
-                { readonly name: "Up"; readonly type: "()" },
-                { readonly name: "Down"; readonly type: "()" },
-                { readonly name: "Left"; readonly type: "()" },
-                { readonly name: "Right"; readonly type: "()" },
-            ];
-        },
-        // ... more ABI entries
-    ];
-};
-
-// Extract ABI types from the properly typed ABI
+// Extract ABI types from the TypeScript version (this works!)
 type MyAbi = ExtractAbiTypes<typeof compiledAbi>;
+
+// Note: If you need the JSON at runtime, you can still import it separately
+// The types come from the TypeScript file, the runtime data from JSON
+
+// IMPORTANT: TypeScript limitation with JSON imports
+// When you import JSON files directly, TypeScript converts all string literals
+// to generic 'string' type, which breaks ExtractAbiTypes.
+//
+// To extract types from JSON files, you must:
+// 1. Run `npx generate-abi-types` in your world directory to create a .ts file
+// 2. Import from the generated .ts file instead of .json
+//
+// The JSON file can still be used at runtime if needed:
+// const runtimeAbi = compiledJson; // This has the actual data
+// type CompileTimeTypes = ExtractAbiTypes<typeof compiledAbi>; // This has the types
 
 // Debug: Check the structure of MyAbi
 type MyAbiStructs = MyAbi["structs"];
 type MyAbiEnums = MyAbi["enums"];
 type MyAbiFunctions = MyAbi["functions"];
+type MyAbiInterfaces = MyAbi["interfaces"];
 
 // Now you can use the extracted types
 type Position = MyAbi["structs"]["dojo_starter::models::Position"]; // { player: string; vec: Vec2 }
 type Vec2 = MyAbi["structs"]["dojo_starter::models::Vec2"]; // { x: number; y: number }
-type Direction = MyAbi["enums"]["dojo_starter::models::Direction"]; // "None" | "Up" | "Down" | "Left" | "Right"
+
+// Enum types now include variants structure
+type Direction = MyAbi["enums"]["dojo_starter::models::Direction"];
+// Direction will be: {
+//   variants: { None: void; Up: void; Down: void; Left: void; Right: void };
+//   type: "None" | "Up" | "Down" | "Left" | "Right";
+// }
+type DirectionType = Direction["type"]; // Union type: "None" | "Up" | "Down" | "Left" | "Right"
+type DirectionVariants = Direction["variants"]; // Object with variant names as keys
+
+// Interface types - access interface functions
+type IWorld = MyAbi["interfaces"]["dojo::world::iworld::IWorld"];
+type WorldResourceFunction = IWorld["resource"]; // { inputs: { selector: string }, outputs: Resource }
+type WorldUuidFunction = IWorld["uuid"]; // { inputs: {}, outputs: number }
+
+// Action interface example
+type IActions = MyAbi["interfaces"]["dojo_starter::systems::actions::IActions"];
+type SpawnFunction = IActions["spawn"]; // { inputs: {}, outputs: void }
+type MoveFunction = IActions["move"]; // { inputs: { direction: Direction["type"] }, outputs: void }
 
 // To make this work with your actual compiled-abi.json, you need to:
 // 1. Create a script that converts compiled-abi.json to a TypeScript file with proper const assertions

--- a/packages/core/src/types/example-usage.ts
+++ b/packages/core/src/types/example-usage.ts
@@ -1,0 +1,103 @@
+import { ExtractAbiTypes } from "./index";
+
+// Example manifest types (these would come from your actual manifest JSON files)
+declare const manifest1: {
+    world: {
+        abi: [
+            {
+                type: "struct";
+                name: "Position";
+                members: [
+                    { name: "x"; type: "core::integer::u32" },
+                    { name: "y"; type: "core::integer::u32" },
+                ];
+            },
+        ];
+    };
+    contracts: [
+        {
+            tag: "actions";
+            abi: [
+                {
+                    type: "function";
+                    name: "move";
+                    inputs: [
+                        { name: "entity"; type: "core::felt252" },
+                        { name: "direction"; type: "core::integer::u8" },
+                    ];
+                    outputs: [];
+                },
+            ];
+        },
+    ];
+};
+
+declare const manifest2: {
+    world: {
+        abi: [
+            {
+                type: "enum";
+                name: "Direction";
+                variants: [
+                    { name: "Up"; type: "()" },
+                    { name: "Down"; type: "()" },
+                    { name: "Left"; type: "()" },
+                    { name: "Right"; type: "()" },
+                ];
+            },
+        ];
+    };
+    contracts: [];
+};
+
+declare const manifest3: {
+    contracts: [
+        {
+            tag: "combat";
+            abi: [
+                {
+                    type: "struct";
+                    name: "Health";
+                    members: [
+                        { name: "current"; type: "core::integer::u32" },
+                        { name: "max"; type: "core::integer::u32" },
+                    ];
+                },
+                {
+                    type: "function";
+                    name: "attack";
+                    inputs: [
+                        { name: "attacker"; type: "core::felt252" },
+                        { name: "target"; type: "core::felt252" },
+                        { name: "damage"; type: "core::integer::u32" },
+                    ];
+                    outputs: [{ type: "core::bool" }];
+                },
+            ];
+        },
+    ];
+};
+
+// Extract ABI types from multiple manifests
+type MyAbi = ExtractAbiTypes<
+    [typeof manifest1, typeof manifest2, typeof manifest3]
+>;
+
+// Now you can use the extracted types
+type Position = MyAbi["structs"]["Position"]; // { x: number; y: number }
+type Direction = MyAbi["enums"]["Direction"]; // "Up" | "Down" | "Left" | "Right"
+type Health = MyAbi["structs"]["Health"]; // { current: number; max: number }
+type MoveFunction = MyAbi["functions"]["move"]; // { inputs: { entity: string; direction: number }; outputs: void }
+type AttackFunction = MyAbi["functions"]["attack"]; // { inputs: { attacker: string; target: string; damage: number }; outputs: boolean }
+
+// Backward compatibility - still works with raw ABI arrays
+declare const abi: [
+    {
+        type: "struct";
+        name: "User";
+        members: [{ name: "name"; type: "core::byte_array::ByteArray" }];
+    },
+];
+
+type SingleAbiTypes = ExtractAbiTypes<typeof abi>;
+type UserType = SingleAbiTypes["structs"]["User"]; // { name: string }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -157,28 +157,80 @@ type CairoToTsTypeMap = {
 };
 
 /**
- * Map Cairo type to TypeScript type
+ * Map Cairo type to TypeScript type with ABI context
  */
-export type MapCairoType<T extends string> = T extends keyof CairoToTsTypeMap
+export type MapCairoType<
+    T extends string,
+    ABI extends readonly any[] = never,
+> = T extends keyof CairoToTsTypeMap
     ? CairoToTsTypeMap[T]
     : T extends `core::array::Array::<${infer Inner}>`
-      ? MapCairoType<Inner>[]
+      ? MapCairoType<Inner, ABI>[]
       : T extends `core::array::Span::<${infer Inner}>`
-        ? MapCairoType<Inner>[]
+        ? MapCairoType<Inner, ABI>[]
         : T extends `@core::array::Array::<${infer Inner}>`
-          ? MapCairoType<Inner>[]
+          ? MapCairoType<Inner, ABI>[]
           : T extends `(${infer Types})`
-            ? MapTupleTypes<Types>
-            : unknown;
+            ? MapTupleTypes<Types, ABI>
+            : ABI extends never
+              ? unknown
+              : T extends ExtractStructNames<ABI>
+                ? ExtractStructType<T, ABI>
+                : T extends ExtractEnumNames<ABI>
+                  ? ExtractEnumType<T, ABI>
+                  : unknown;
+
+/**
+ * Extract all struct names from ABI
+ */
+type ExtractStructNames<ABI extends readonly any[]> = Extract<
+    ABI[number],
+    { type: "struct"; name: string }
+>["name"];
+
+/**
+ * Find the first struct with a specific name in the ABI
+ * This prevents duplicate struct definitions from creating union types
+ */
+type FindFirstStructByName<
+    ABI extends readonly any[],
+    Name extends string,
+> = ABI extends readonly [infer First, ...infer Rest extends readonly any[]]
+    ? First extends { type: "struct"; name: Name }
+        ? First
+        : FindFirstStructByName<Rest, Name>
+    : never;
+
+/**
+ * Extract a specific struct type by name from ABI
+ * Only uses the first occurrence of a struct with the given name
+ */
+type ExtractStructType<
+    Name extends string,
+    ABI extends readonly any[],
+> = FindFirstStructByName<ABI, Name> extends {
+    type: "struct";
+    name: Name;
+    members: infer M;
+}
+    ? M extends readonly { name: string; type: string }[]
+        ? {
+              [P in M[number] as P["name"]]: MapCairoType<P["type"], ABI>;
+          }
+        : never
+    : never;
 
 /**
  * Map tuple types
  */
-type MapTupleTypes<T extends string> = T extends `${infer First}, ${infer Rest}`
-    ? [MapCairoType<First>, ...MapTupleTypes<Rest>]
+type MapTupleTypes<
+    T extends string,
+    ABI extends readonly any[] = never,
+> = T extends `${infer First}, ${infer Rest}`
+    ? [MapCairoType<First, ABI>, ...MapTupleTypes<Rest, ABI>]
     : T extends ""
       ? []
-      : [MapCairoType<T>];
+      : [MapCairoType<T, ABI>];
 
 // ========================
 // ABI Type Extraction
@@ -187,7 +239,10 @@ type MapTupleTypes<T extends string> = T extends `${infer First}, ${infer Rest}`
 /**
  * Extract function signature from a function item
  */
-type ExtractFunctionSignature<F> = F extends {
+type ExtractFunctionSignature<
+    F,
+    ABI extends readonly any[] = never,
+> = F extends {
     type: "function";
     name: string;
     inputs: infer I;
@@ -199,19 +254,19 @@ type ExtractFunctionSignature<F> = F extends {
               type: string;
           }[]
               ? {
-                    [P in I[number] as P["name"]]: MapCairoType<P["type"]>;
+                    [P in I[number] as P["name"]]: MapCairoType<P["type"], ABI>;
                 }
               : never;
           outputs: O extends readonly { type: string }[]
               ? O["length"] extends 0
                   ? void
                   : O["length"] extends 1
-                    ? MapCairoType<O[0]["type"]>
+                    ? MapCairoType<O[0]["type"], ABI>
                     : {
                           [Index in keyof O]: O[Index] extends {
                               type: string;
                           }
-                              ? MapCairoType<O[Index]["type"]>
+                              ? MapCairoType<O[Index]["type"], ABI>
                               : never;
                       }
               : void;
@@ -223,86 +278,162 @@ type ExtractFunctionSignature<F> = F extends {
  */
 export type ExtractAbiTypesFromArray<ABI> = ABI extends readonly any[]
     ? {
-          structs: {
-              [K in ABI[number] as K extends { type: "struct"; name: infer N }
-                  ? N extends string
-                      ? N
-                      : never
-                  : never]: K extends {
-                  type: "struct";
-                  name: string;
-                  members: infer M;
-              }
-                  ? M extends readonly { name: string; type: string }[]
-                      ? {
-                            [P in M[number] as P["name"]]: MapCairoType<
-                                P["type"]
-                            >;
-                        }
-                      : never
-                  : never;
-          };
-          enums: {
-              [K in ABI[number] as K extends { type: "enum"; name: infer N }
-                  ? N extends string
-                      ? N
-                      : never
-                  : never]: K extends {
-                  type: "enum";
-                  name: string;
-                  variants: infer V;
-              }
-                  ? V extends readonly { name: string; type: string }[]
-                      ? {
-                            variants: {
-                                [P in V[number] as P["name"]]: MapCairoType<
-                                    P["type"]
-                                >;
-                            };
-                            type: V[number]["name"];
-                        }
-                      : never
-                  : never;
-          };
-          functions: {
-              [K in ABI[number] as K extends {
-                  type: "function";
-                  name: infer N;
-              }
-                  ? N extends string
-                      ? N
-                      : never
-                  : never]: ExtractFunctionSignature<K>;
-          };
-          interfaces: {
-              [K in ABI[number] as K extends {
-                  type: "interface";
-                  name: infer N;
-              }
-                  ? N extends string
-                      ? N
-                      : never
-                  : never]: K extends {
-                  type: "interface";
-                  name: string;
-                  items: infer Items;
-              }
-                  ? Items extends readonly any[]
-                      ? {
-                            [F in Items[number] as F extends {
-                                type: "function";
-                                name: infer FN;
-                            }
-                                ? FN extends string
-                                    ? FN
-                                    : never
-                                : never]: ExtractFunctionSignature<F>;
-                        }
-                      : {}
-                  : never;
-          };
+          structs: ExtractStructs<ABI>;
+          enums: ExtractEnums<ABI>;
+          functions: ExtractFunctions<ABI>;
+          interfaces: ExtractInterfaces<ABI>;
       }
     : never;
+
+/**
+ * Helper type to extract structs from ABI
+ */
+type ExtractStructs<ABI extends readonly any[]> = {
+    [StructName in ExtractStructNames<ABI>]: ExtractStructType<StructName, ABI>;
+};
+
+/**
+ * Find the first enum with a specific name in the ABI
+ * This prevents duplicate enum definitions from creating union types
+ */
+type FindFirstEnumByName<
+    ABI extends readonly any[],
+    Name extends string,
+> = ABI extends readonly [infer First, ...infer Rest extends readonly any[]]
+    ? First extends { type: "enum"; name: Name }
+        ? First
+        : FindFirstEnumByName<Rest, Name>
+    : never;
+
+/**
+ * Extract all enum names from ABI
+ */
+type ExtractEnumNames<ABI extends readonly any[]> = Extract<
+    ABI[number],
+    { type: "enum"; name: string }
+>["name"];
+
+/**
+ * Extract just the type union of an enum by name
+ * This is used for type mapping in function parameters
+ */
+type ExtractEnumType<
+    Name extends string,
+    ABI extends readonly any[],
+> = FindFirstEnumByName<ABI, Name> extends {
+    type: "enum";
+    name: Name;
+    variants: infer V;
+}
+    ? V extends readonly { name: string; type: string }[]
+        ? V[number]["name"]
+        : never
+    : never;
+
+/**
+ * Helper type to extract enums from ABI
+ */
+type ExtractEnums<ABI extends readonly any[]> = {
+    [EnumName in ExtractEnumNames<ABI>]: FindFirstEnumByName<
+        ABI,
+        EnumName
+    > extends {
+        type: "enum";
+        name: EnumName;
+        variants: infer V;
+    }
+        ? V extends readonly { name: string; type: string }[]
+            ? {
+                  variants: {
+                      [P in V[number] as P["name"]]: MapCairoType<
+                          P["type"],
+                          ABI
+                      >;
+                  };
+                  type: V[number]["name"];
+              }
+            : never
+        : never;
+};
+
+/**
+ * Find the first function with a specific name in the ABI
+ * This prevents duplicate function definitions from creating union types
+ */
+type FindFirstFunctionByName<
+    ABI extends readonly any[],
+    Name extends string,
+> = ABI extends readonly [infer First, ...infer Rest extends readonly any[]]
+    ? First extends { type: "function"; name: Name }
+        ? First
+        : FindFirstFunctionByName<Rest, Name>
+    : never;
+
+/**
+ * Extract all function names from ABI
+ */
+type ExtractFunctionNames<ABI extends readonly any[]> = Extract<
+    ABI[number],
+    { type: "function"; name: string }
+>["name"];
+
+/**
+ * Helper type to extract functions from ABI
+ */
+type ExtractFunctions<ABI extends readonly any[]> = {
+    [FunctionName in ExtractFunctionNames<ABI>]: ExtractFunctionSignature<
+        FindFirstFunctionByName<ABI, FunctionName>,
+        ABI
+    >;
+};
+
+/**
+ * Find the first interface with a specific name in the ABI
+ * This prevents duplicate interface definitions from creating union types
+ */
+type FindFirstInterfaceByName<
+    ABI extends readonly any[],
+    Name extends string,
+> = ABI extends readonly [infer First, ...infer Rest extends readonly any[]]
+    ? First extends { type: "interface"; name: Name }
+        ? First
+        : FindFirstInterfaceByName<Rest, Name>
+    : never;
+
+/**
+ * Extract all interface names from ABI
+ */
+type ExtractInterfaceNames<ABI extends readonly any[]> = Extract<
+    ABI[number],
+    { type: "interface"; name: string }
+>["name"];
+
+/**
+ * Helper type to extract interfaces from ABI
+ */
+type ExtractInterfaces<ABI extends readonly any[]> = {
+    [InterfaceName in ExtractInterfaceNames<ABI>]: FindFirstInterfaceByName<
+        ABI,
+        InterfaceName
+    > extends {
+        type: "interface";
+        name: InterfaceName;
+        items: infer Items;
+    }
+        ? Items extends readonly any[]
+            ? {
+                  [F in Items[number] as F extends {
+                      type: "function";
+                      name: infer FN;
+                  }
+                      ? FN extends string
+                          ? FN
+                          : never
+                      : never]: ExtractFunctionSignature<F, ABI>;
+              }
+            : {}
+        : never;
+};
 
 /**
  * Main exported type for extracting ABI types

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,5 +17,5 @@
     },
     "include": ["src/**/*.ts", "_test_/**/*.test.ts"],
     "skipLibCheck": true,
-    "exclude": ["node_modules", "dist", "**/*.test.ts"]
+    "exclude": ["node_modules", "dist", "**/*.test.ts", "src/types/example-usage.ts"]
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -4,6 +4,11 @@ import { tsupConfig } from "../../tsup.config";
 
 export default defineConfig({
     ...(tsupConfig as Options),
+    entry: [
+        "src/index.ts",
+        "src/cli/compile-abi.ts",
+        "src/cli/generate-abi-types.ts",
+    ],
     minify: false,
     splitting: false,
 });

--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -14,8 +14,6 @@
         "build": "pnpm build:proto && pnpm build:deps",
         "format:check": "biome format .",
         "format": "biome format . --write",
-        "lint:check": "biome check .",
-        "lint": "biome check . --write",
         "test": "vitest run --passWithNoTests --coverage",
         "bench": "vitest bench --config vitest.config.bench.ts",
         "bench:report": "bun run src/benchmarks/report.ts",

--- a/packages/grpc/src/example.ts
+++ b/packages/grpc/src/example.ts
@@ -6,7 +6,7 @@ import { ToriiQueryBuilder } from "@dojoengine/sdk/node";
 async function main() {
     // Create a client with the same config as torii-wasm
     const client = new ToriiGrpcClient({
-        toriiUrl: "http://localhost:8080",
+        toriiUrl: "https://api.cartridge.gg/x/arcade-briq/torii",
         worldAddress:
             "0x0248f59aeb5c6a086409dc1ec588f0f5346b29960e7e64d10c133bcc85ba7244",
     });

--- a/packages/grpc/src/generated/google/protobuf/empty.ts
+++ b/packages/grpc/src/generated/google/protobuf/empty.ts
@@ -52,60 +52,39 @@ import { MessageType } from "@protobuf-ts/runtime";
  *
  * @generated from protobuf message google.protobuf.Empty
  */
-export interface Empty {}
+export interface Empty {
+}
 // @generated message type with reflection information, may provide speed optimized methods
 class Empty$Type extends MessageType<Empty> {
     constructor() {
         super("google.protobuf.Empty", []);
     }
     create(value?: PartialMessage<Empty>): Empty {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
             reflectionMergePartial<Empty>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Empty
-    ): Empty {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Empty): Empty {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Empty,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Empty, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }

--- a/packages/grpc/src/generated/schema.ts
+++ b/packages/grpc/src/generated/schema.ts
@@ -47,122 +47,105 @@ export interface Primitive {
     /**
      * @generated from protobuf oneof: primitive_type
      */
-    primitive_type:
-        | {
-              oneofKind: "i8";
-              /**
-               * @generated from protobuf field: int32 i8 = 1
-               */
-              i8: number;
-          }
-        | {
-              oneofKind: "i16";
-              /**
-               * @generated from protobuf field: int32 i16 = 2
-               */
-              i16: number;
-          }
-        | {
-              oneofKind: "i32";
-              /**
-               * @generated from protobuf field: int32 i32 = 3
-               */
-              i32: number;
-          }
-        | {
-              oneofKind: "i64";
-              /**
-               * @generated from protobuf field: int64 i64 = 4
-               */
-              i64: bigint;
-          }
-        | {
-              oneofKind: "i128";
-              /**
-               * @generated from protobuf field: bytes i128 = 5
-               */
-              i128: Uint8Array;
-          }
-        | {
-              oneofKind: "u8";
-              /**
-               * @generated from protobuf field: uint32 u8 = 6
-               */
-              u8: number;
-          }
-        | {
-              oneofKind: "u16";
-              /**
-               * @generated from protobuf field: uint32 u16 = 7
-               */
-              u16: number;
-          }
-        | {
-              oneofKind: "u32";
-              /**
-               * @generated from protobuf field: uint32 u32 = 8
-               */
-              u32: number;
-          }
-        | {
-              oneofKind: "u64";
-              /**
-               * @generated from protobuf field: uint64 u64 = 9
-               */
-              u64: bigint;
-          }
-        | {
-              oneofKind: "u128";
-              /**
-               * @generated from protobuf field: bytes u128 = 10
-               */
-              u128: Uint8Array;
-          }
-        | {
-              oneofKind: "u256";
-              /**
-               * @generated from protobuf field: bytes u256 = 11
-               */
-              u256: Uint8Array;
-          }
-        | {
-              oneofKind: "bool";
-              /**
-               * @generated from protobuf field: bool bool = 12
-               */
-              bool: boolean;
-          }
-        | {
-              oneofKind: "felt252";
-              /**
-               * @generated from protobuf field: bytes felt252 = 13
-               */
-              felt252: Uint8Array;
-          }
-        | {
-              oneofKind: "class_hash";
-              /**
-               * @generated from protobuf field: bytes class_hash = 14
-               */
-              class_hash: Uint8Array;
-          }
-        | {
-              oneofKind: "contract_address";
-              /**
-               * @generated from protobuf field: bytes contract_address = 15
-               */
-              contract_address: Uint8Array;
-          }
-        | {
-              oneofKind: "eth_address";
-              /**
-               * @generated from protobuf field: bytes eth_address = 16
-               */
-              eth_address: Uint8Array;
-          }
-        | {
-              oneofKind: undefined;
-          };
+    primitive_type: {
+        oneofKind: "i8";
+        /**
+         * @generated from protobuf field: int32 i8 = 1
+         */
+        i8: number;
+    } | {
+        oneofKind: "i16";
+        /**
+         * @generated from protobuf field: int32 i16 = 2
+         */
+        i16: number;
+    } | {
+        oneofKind: "i32";
+        /**
+         * @generated from protobuf field: int32 i32 = 3
+         */
+        i32: number;
+    } | {
+        oneofKind: "i64";
+        /**
+         * @generated from protobuf field: int64 i64 = 4
+         */
+        i64: bigint;
+    } | {
+        oneofKind: "i128";
+        /**
+         * @generated from protobuf field: bytes i128 = 5
+         */
+        i128: Uint8Array;
+    } | {
+        oneofKind: "u8";
+        /**
+         * @generated from protobuf field: uint32 u8 = 6
+         */
+        u8: number;
+    } | {
+        oneofKind: "u16";
+        /**
+         * @generated from protobuf field: uint32 u16 = 7
+         */
+        u16: number;
+    } | {
+        oneofKind: "u32";
+        /**
+         * @generated from protobuf field: uint32 u32 = 8
+         */
+        u32: number;
+    } | {
+        oneofKind: "u64";
+        /**
+         * @generated from protobuf field: uint64 u64 = 9
+         */
+        u64: bigint;
+    } | {
+        oneofKind: "u128";
+        /**
+         * @generated from protobuf field: bytes u128 = 10
+         */
+        u128: Uint8Array;
+    } | {
+        oneofKind: "u256";
+        /**
+         * @generated from protobuf field: bytes u256 = 11
+         */
+        u256: Uint8Array;
+    } | {
+        oneofKind: "bool";
+        /**
+         * @generated from protobuf field: bool bool = 12
+         */
+        bool: boolean;
+    } | {
+        oneofKind: "felt252";
+        /**
+         * @generated from protobuf field: bytes felt252 = 13
+         */
+        felt252: Uint8Array;
+    } | {
+        oneofKind: "class_hash";
+        /**
+         * @generated from protobuf field: bytes class_hash = 14
+         */
+        class_hash: Uint8Array;
+    } | {
+        oneofKind: "contract_address";
+        /**
+         * @generated from protobuf field: bytes contract_address = 15
+         */
+        contract_address: Uint8Array;
+    } | {
+        oneofKind: "eth_address";
+        /**
+         * @generated from protobuf field: bytes eth_address = 16
+         */
+        eth_address: Uint8Array;
+    } | {
+        oneofKind: undefined;
+    };
 }
 /**
  * @generated from protobuf message types.Struct
@@ -193,52 +176,45 @@ export interface Ty {
     /**
      * @generated from protobuf oneof: ty_type
      */
-    ty_type:
-        | {
-              oneofKind: "primitive";
-              /**
-               * @generated from protobuf field: types.Primitive primitive = 2
-               */
-              primitive: Primitive;
-          }
-        | {
-              oneofKind: "enum";
-              /**
-               * @generated from protobuf field: types.Enum enum = 3
-               */
-              enum: Enum;
-          }
-        | {
-              oneofKind: "struct";
-              /**
-               * @generated from protobuf field: types.Struct struct = 4
-               */
-              struct: Struct;
-          }
-        | {
-              oneofKind: "tuple";
-              /**
-               * @generated from protobuf field: types.Array tuple = 5
-               */
-              tuple: Array$;
-          }
-        | {
-              oneofKind: "array";
-              /**
-               * @generated from protobuf field: types.Array array = 6
-               */
-              array: Array$;
-          }
-        | {
-              oneofKind: "bytearray";
-              /**
-               * @generated from protobuf field: string bytearray = 7
-               */
-              bytearray: string;
-          }
-        | {
-              oneofKind: undefined;
-          };
+    ty_type: {
+        oneofKind: "primitive";
+        /**
+         * @generated from protobuf field: types.Primitive primitive = 2
+         */
+        primitive: Primitive;
+    } | {
+        oneofKind: "enum";
+        /**
+         * @generated from protobuf field: types.Enum enum = 3
+         */
+        enum: Enum;
+    } | {
+        oneofKind: "struct";
+        /**
+         * @generated from protobuf field: types.Struct struct = 4
+         */
+        struct: Struct;
+    } | {
+        oneofKind: "tuple";
+        /**
+         * @generated from protobuf field: types.Array tuple = 5
+         */
+        tuple: Array$;
+    } | {
+        oneofKind: "array";
+        /**
+         * @generated from protobuf field: types.Array array = 6
+         */
+        array: Array$;
+    } | {
+        oneofKind: "bytearray";
+        /**
+         * @generated from protobuf field: string bytearray = 7
+         */
+        bytearray: string;
+    } | {
+        oneofKind: undefined;
+    };
 }
 /**
  * @generated from protobuf message types.Member
@@ -262,24 +238,18 @@ class EnumOption$Type extends MessageType<EnumOption> {
     constructor() {
         super("types.EnumOption", [
             { no: 1, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "ty", kind: "message", T: () => Ty },
+            { no: 2, name: "ty", kind: "message", T: () => Ty }
         ]);
     }
     create(value?: PartialMessage<EnumOption>): EnumOption {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.name = "";
         if (value !== undefined)
             reflectionMergePartial<EnumOption>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: EnumOption
-    ): EnumOption {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOption): EnumOption {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -287,54 +257,29 @@ class EnumOption$Type extends MessageType<EnumOption> {
                     message.name = reader.string();
                     break;
                 case /* types.Ty ty */ 2:
-                    message.ty = Ty.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.ty
-                    );
+                    message.ty = Ty.internalBinaryRead(reader, reader.uint32(), options, message.ty);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: EnumOption,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: EnumOption, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string name = 1; */
         if (message.name !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.name);
         /* types.Ty ty = 2; */
         if (message.ty)
-            Ty.internalBinaryWrite(
-                message.ty,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Ty.internalBinaryWrite(message.ty, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -347,23 +292,12 @@ class Enum$Type extends MessageType<Enum> {
     constructor() {
         super("types.Enum", [
             { no: 1, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            {
-                no: 2,
-                name: "option",
-                kind: "scalar",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 3,
-                name: "options",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => EnumOption,
-            },
+            { no: 2, name: "option", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 3, name: "options", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => EnumOption }
         ]);
     }
     create(value?: PartialMessage<Enum>): Enum {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.name = "";
         message.option = 0;
         message.options = [];
@@ -371,14 +305,8 @@ class Enum$Type extends MessageType<Enum> {
             reflectionMergePartial<Enum>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Enum
-    ): Enum {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Enum): Enum {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -389,38 +317,20 @@ class Enum$Type extends MessageType<Enum> {
                     message.option = reader.uint32();
                     break;
                 case /* repeated types.EnumOption options */ 3:
-                    message.options.push(
-                        EnumOption.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.options.push(EnumOption.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Enum,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Enum, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string name = 1; */
         if (message.name !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.name);
@@ -429,18 +339,10 @@ class Enum$Type extends MessageType<Enum> {
             writer.tag(2, WireType.Varint).uint32(message.option);
         /* repeated types.EnumOption options = 3; */
         for (let i = 0; i < message.options.length; i++)
-            EnumOption.internalBinaryWrite(
-                message.options[i],
-                writer.tag(3, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            EnumOption.internalBinaryWrite(message.options[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -452,263 +354,144 @@ export const Enum = new Enum$Type();
 class Primitive$Type extends MessageType<Primitive> {
     constructor() {
         super("types.Primitive", [
-            {
-                no: 1,
-                name: "i8",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 5 /*ScalarType.INT32*/,
-            },
-            {
-                no: 2,
-                name: "i16",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 5 /*ScalarType.INT32*/,
-            },
-            {
-                no: 3,
-                name: "i32",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 5 /*ScalarType.INT32*/,
-            },
-            {
-                no: 4,
-                name: "i64",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 3 /*ScalarType.INT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 5,
-                name: "i128",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 6,
-                name: "u8",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 7,
-                name: "u16",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 8,
-                name: "u32",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 9,
-                name: "u64",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 10,
-                name: "u128",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 11,
-                name: "u256",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 12,
-                name: "bool",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 8 /*ScalarType.BOOL*/,
-            },
-            {
-                no: 13,
-                name: "felt252",
-                kind: "scalar",
-                oneof: "primitive_type",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 14,
-                name: "class_hash",
-                kind: "scalar",
-                localName: "class_hash",
-                oneof: "primitive_type",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 15,
-                name: "contract_address",
-                kind: "scalar",
-                localName: "contract_address",
-                oneof: "primitive_type",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 16,
-                name: "eth_address",
-                kind: "scalar",
-                localName: "eth_address",
-                oneof: "primitive_type",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "i8", kind: "scalar", oneof: "primitive_type", T: 5 /*ScalarType.INT32*/ },
+            { no: 2, name: "i16", kind: "scalar", oneof: "primitive_type", T: 5 /*ScalarType.INT32*/ },
+            { no: 3, name: "i32", kind: "scalar", oneof: "primitive_type", T: 5 /*ScalarType.INT32*/ },
+            { no: 4, name: "i64", kind: "scalar", oneof: "primitive_type", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 5, name: "i128", kind: "scalar", oneof: "primitive_type", T: 12 /*ScalarType.BYTES*/ },
+            { no: 6, name: "u8", kind: "scalar", oneof: "primitive_type", T: 13 /*ScalarType.UINT32*/ },
+            { no: 7, name: "u16", kind: "scalar", oneof: "primitive_type", T: 13 /*ScalarType.UINT32*/ },
+            { no: 8, name: "u32", kind: "scalar", oneof: "primitive_type", T: 13 /*ScalarType.UINT32*/ },
+            { no: 9, name: "u64", kind: "scalar", oneof: "primitive_type", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 10, name: "u128", kind: "scalar", oneof: "primitive_type", T: 12 /*ScalarType.BYTES*/ },
+            { no: 11, name: "u256", kind: "scalar", oneof: "primitive_type", T: 12 /*ScalarType.BYTES*/ },
+            { no: 12, name: "bool", kind: "scalar", oneof: "primitive_type", T: 8 /*ScalarType.BOOL*/ },
+            { no: 13, name: "felt252", kind: "scalar", oneof: "primitive_type", T: 12 /*ScalarType.BYTES*/ },
+            { no: 14, name: "class_hash", kind: "scalar", localName: "class_hash", oneof: "primitive_type", T: 12 /*ScalarType.BYTES*/ },
+            { no: 15, name: "contract_address", kind: "scalar", localName: "contract_address", oneof: "primitive_type", T: 12 /*ScalarType.BYTES*/ },
+            { no: 16, name: "eth_address", kind: "scalar", localName: "eth_address", oneof: "primitive_type", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<Primitive>): Primitive {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.primitive_type = { oneofKind: undefined };
         if (value !== undefined)
             reflectionMergePartial<Primitive>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Primitive
-    ): Primitive {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Primitive): Primitive {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* int32 i8 */ 1:
                     message.primitive_type = {
                         oneofKind: "i8",
-                        i8: reader.int32(),
+                        i8: reader.int32()
                     };
                     break;
                 case /* int32 i16 */ 2:
                     message.primitive_type = {
                         oneofKind: "i16",
-                        i16: reader.int32(),
+                        i16: reader.int32()
                     };
                     break;
                 case /* int32 i32 */ 3:
                     message.primitive_type = {
                         oneofKind: "i32",
-                        i32: reader.int32(),
+                        i32: reader.int32()
                     };
                     break;
                 case /* int64 i64 */ 4:
                     message.primitive_type = {
                         oneofKind: "i64",
-                        i64: reader.int64().toBigInt(),
+                        i64: reader.int64().toBigInt()
                     };
                     break;
                 case /* bytes i128 */ 5:
                     message.primitive_type = {
                         oneofKind: "i128",
-                        i128: reader.bytes(),
+                        i128: reader.bytes()
                     };
                     break;
                 case /* uint32 u8 */ 6:
                     message.primitive_type = {
                         oneofKind: "u8",
-                        u8: reader.uint32(),
+                        u8: reader.uint32()
                     };
                     break;
                 case /* uint32 u16 */ 7:
                     message.primitive_type = {
                         oneofKind: "u16",
-                        u16: reader.uint32(),
+                        u16: reader.uint32()
                     };
                     break;
                 case /* uint32 u32 */ 8:
                     message.primitive_type = {
                         oneofKind: "u32",
-                        u32: reader.uint32(),
+                        u32: reader.uint32()
                     };
                     break;
                 case /* uint64 u64 */ 9:
                     message.primitive_type = {
                         oneofKind: "u64",
-                        u64: reader.uint64().toBigInt(),
+                        u64: reader.uint64().toBigInt()
                     };
                     break;
                 case /* bytes u128 */ 10:
                     message.primitive_type = {
                         oneofKind: "u128",
-                        u128: reader.bytes(),
+                        u128: reader.bytes()
                     };
                     break;
                 case /* bytes u256 */ 11:
                     message.primitive_type = {
                         oneofKind: "u256",
-                        u256: reader.bytes(),
+                        u256: reader.bytes()
                     };
                     break;
                 case /* bool bool */ 12:
                     message.primitive_type = {
                         oneofKind: "bool",
-                        bool: reader.bool(),
+                        bool: reader.bool()
                     };
                     break;
                 case /* bytes felt252 */ 13:
                     message.primitive_type = {
                         oneofKind: "felt252",
-                        felt252: reader.bytes(),
+                        felt252: reader.bytes()
                     };
                     break;
                 case /* bytes class_hash */ 14:
                     message.primitive_type = {
                         oneofKind: "class_hash",
-                        class_hash: reader.bytes(),
+                        class_hash: reader.bytes()
                     };
                     break;
                 case /* bytes contract_address */ 15:
                     message.primitive_type = {
                         oneofKind: "contract_address",
-                        contract_address: reader.bytes(),
+                        contract_address: reader.bytes()
                     };
                     break;
                 case /* bytes eth_address */ 16:
                     message.primitive_type = {
                         oneofKind: "eth_address",
-                        eth_address: reader.bytes(),
+                        eth_address: reader.bytes()
                     };
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Primitive,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Primitive, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* int32 i8 = 1; */
         if (message.primitive_type.oneofKind === "i8")
             writer.tag(1, WireType.Varint).int32(message.primitive_type.i8);
@@ -723,9 +506,7 @@ class Primitive$Type extends MessageType<Primitive> {
             writer.tag(4, WireType.Varint).int64(message.primitive_type.i64);
         /* bytes i128 = 5; */
         if (message.primitive_type.oneofKind === "i128")
-            writer
-                .tag(5, WireType.LengthDelimited)
-                .bytes(message.primitive_type.i128);
+            writer.tag(5, WireType.LengthDelimited).bytes(message.primitive_type.i128);
         /* uint32 u8 = 6; */
         if (message.primitive_type.oneofKind === "u8")
             writer.tag(6, WireType.Varint).uint32(message.primitive_type.u8);
@@ -740,44 +521,28 @@ class Primitive$Type extends MessageType<Primitive> {
             writer.tag(9, WireType.Varint).uint64(message.primitive_type.u64);
         /* bytes u128 = 10; */
         if (message.primitive_type.oneofKind === "u128")
-            writer
-                .tag(10, WireType.LengthDelimited)
-                .bytes(message.primitive_type.u128);
+            writer.tag(10, WireType.LengthDelimited).bytes(message.primitive_type.u128);
         /* bytes u256 = 11; */
         if (message.primitive_type.oneofKind === "u256")
-            writer
-                .tag(11, WireType.LengthDelimited)
-                .bytes(message.primitive_type.u256);
+            writer.tag(11, WireType.LengthDelimited).bytes(message.primitive_type.u256);
         /* bool bool = 12; */
         if (message.primitive_type.oneofKind === "bool")
             writer.tag(12, WireType.Varint).bool(message.primitive_type.bool);
         /* bytes felt252 = 13; */
         if (message.primitive_type.oneofKind === "felt252")
-            writer
-                .tag(13, WireType.LengthDelimited)
-                .bytes(message.primitive_type.felt252);
+            writer.tag(13, WireType.LengthDelimited).bytes(message.primitive_type.felt252);
         /* bytes class_hash = 14; */
         if (message.primitive_type.oneofKind === "class_hash")
-            writer
-                .tag(14, WireType.LengthDelimited)
-                .bytes(message.primitive_type.class_hash);
+            writer.tag(14, WireType.LengthDelimited).bytes(message.primitive_type.class_hash);
         /* bytes contract_address = 15; */
         if (message.primitive_type.oneofKind === "contract_address")
-            writer
-                .tag(15, WireType.LengthDelimited)
-                .bytes(message.primitive_type.contract_address);
+            writer.tag(15, WireType.LengthDelimited).bytes(message.primitive_type.contract_address);
         /* bytes eth_address = 16; */
         if (message.primitive_type.oneofKind === "eth_address")
-            writer
-                .tag(16, WireType.LengthDelimited)
-                .bytes(message.primitive_type.eth_address);
+            writer.tag(16, WireType.LengthDelimited).bytes(message.primitive_type.eth_address);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -790,31 +555,19 @@ class Struct$Type extends MessageType<Struct> {
     constructor() {
         super("types.Struct", [
             { no: 1, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            {
-                no: 2,
-                name: "children",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Member,
-            },
+            { no: 2, name: "children", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Member }
         ]);
     }
     create(value?: PartialMessage<Struct>): Struct {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.name = "";
         message.children = [];
         if (value !== undefined)
             reflectionMergePartial<Struct>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Struct
-    ): Struct {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Struct): Struct {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -822,55 +575,29 @@ class Struct$Type extends MessageType<Struct> {
                     message.name = reader.string();
                     break;
                 case /* repeated types.Member children */ 2:
-                    message.children.push(
-                        Member.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.children.push(Member.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Struct,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Struct, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string name = 1; */
         if (message.name !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.name);
         /* repeated types.Member children = 2; */
         for (let i = 0; i < message.children.length; i++)
-            Member.internalBinaryWrite(
-                message.children[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Member.internalBinaryWrite(message.children[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -882,76 +609,42 @@ export const Struct = new Struct$Type();
 class Array$$Type extends MessageType<Array$> {
     constructor() {
         super("types.Array", [
-            {
-                no: 1,
-                name: "children",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Ty,
-            },
+            { no: 1, name: "children", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Ty }
         ]);
     }
     create(value?: PartialMessage<Array$>): Array$ {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.children = [];
         if (value !== undefined)
             reflectionMergePartial<Array$>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Array$
-    ): Array$ {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Array$): Array$ {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* repeated types.Ty children */ 1:
-                    message.children.push(
-                        Ty.internalBinaryRead(reader, reader.uint32(), options)
-                    );
+                    message.children.push(Ty.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Array$,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Array$, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated types.Ty children = 1; */
         for (let i = 0; i < message.children.length; i++)
-            Ty.internalBinaryWrite(
-                message.children[i],
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Ty.internalBinaryWrite(message.children[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -963,200 +656,95 @@ export const Array$ = new Array$$Type();
 class Ty$Type extends MessageType<Ty> {
     constructor() {
         super("types.Ty", [
-            {
-                no: 2,
-                name: "primitive",
-                kind: "message",
-                oneof: "ty_type",
-                T: () => Primitive,
-            },
-            {
-                no: 3,
-                name: "enum",
-                kind: "message",
-                oneof: "ty_type",
-                T: () => Enum,
-            },
-            {
-                no: 4,
-                name: "struct",
-                kind: "message",
-                oneof: "ty_type",
-                T: () => Struct,
-            },
-            {
-                no: 5,
-                name: "tuple",
-                kind: "message",
-                oneof: "ty_type",
-                T: () => Array$,
-            },
-            {
-                no: 6,
-                name: "array",
-                kind: "message",
-                oneof: "ty_type",
-                T: () => Array$,
-            },
-            {
-                no: 7,
-                name: "bytearray",
-                kind: "scalar",
-                oneof: "ty_type",
-                T: 9 /*ScalarType.STRING*/,
-            },
+            { no: 2, name: "primitive", kind: "message", oneof: "ty_type", T: () => Primitive },
+            { no: 3, name: "enum", kind: "message", oneof: "ty_type", T: () => Enum },
+            { no: 4, name: "struct", kind: "message", oneof: "ty_type", T: () => Struct },
+            { no: 5, name: "tuple", kind: "message", oneof: "ty_type", T: () => Array$ },
+            { no: 6, name: "array", kind: "message", oneof: "ty_type", T: () => Array$ },
+            { no: 7, name: "bytearray", kind: "scalar", oneof: "ty_type", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<Ty>): Ty {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.ty_type = { oneofKind: undefined };
         if (value !== undefined)
             reflectionMergePartial<Ty>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Ty
-    ): Ty {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Ty): Ty {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Primitive primitive */ 2:
                     message.ty_type = {
                         oneofKind: "primitive",
-                        primitive: Primitive.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.ty_type as any).primitive
-                        ),
+                        primitive: Primitive.internalBinaryRead(reader, reader.uint32(), options, (message.ty_type as any).primitive)
                     };
                     break;
                 case /* types.Enum enum */ 3:
                     message.ty_type = {
                         oneofKind: "enum",
-                        enum: Enum.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.ty_type as any).enum
-                        ),
+                        enum: Enum.internalBinaryRead(reader, reader.uint32(), options, (message.ty_type as any).enum)
                     };
                     break;
                 case /* types.Struct struct */ 4:
                     message.ty_type = {
                         oneofKind: "struct",
-                        struct: Struct.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.ty_type as any).struct
-                        ),
+                        struct: Struct.internalBinaryRead(reader, reader.uint32(), options, (message.ty_type as any).struct)
                     };
                     break;
                 case /* types.Array tuple */ 5:
                     message.ty_type = {
                         oneofKind: "tuple",
-                        tuple: Array$.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.ty_type as any).tuple
-                        ),
+                        tuple: Array$.internalBinaryRead(reader, reader.uint32(), options, (message.ty_type as any).tuple)
                     };
                     break;
                 case /* types.Array array */ 6:
                     message.ty_type = {
                         oneofKind: "array",
-                        array: Array$.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.ty_type as any).array
-                        ),
+                        array: Array$.internalBinaryRead(reader, reader.uint32(), options, (message.ty_type as any).array)
                     };
                     break;
                 case /* string bytearray */ 7:
                     message.ty_type = {
                         oneofKind: "bytearray",
-                        bytearray: reader.string(),
+                        bytearray: reader.string()
                     };
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Ty,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Ty, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Primitive primitive = 2; */
         if (message.ty_type.oneofKind === "primitive")
-            Primitive.internalBinaryWrite(
-                message.ty_type.primitive,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Primitive.internalBinaryWrite(message.ty_type.primitive, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         /* types.Enum enum = 3; */
         if (message.ty_type.oneofKind === "enum")
-            Enum.internalBinaryWrite(
-                message.ty_type.enum,
-                writer.tag(3, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Enum.internalBinaryWrite(message.ty_type.enum, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         /* types.Struct struct = 4; */
         if (message.ty_type.oneofKind === "struct")
-            Struct.internalBinaryWrite(
-                message.ty_type.struct,
-                writer.tag(4, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Struct.internalBinaryWrite(message.ty_type.struct, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         /* types.Array tuple = 5; */
         if (message.ty_type.oneofKind === "tuple")
-            Array$.internalBinaryWrite(
-                message.ty_type.tuple,
-                writer.tag(5, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Array$.internalBinaryWrite(message.ty_type.tuple, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
         /* types.Array array = 6; */
         if (message.ty_type.oneofKind === "array")
-            Array$.internalBinaryWrite(
-                message.ty_type.array,
-                writer.tag(6, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Array$.internalBinaryWrite(message.ty_type.array, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* string bytearray = 7; */
         if (message.ty_type.oneofKind === "bytearray")
-            writer
-                .tag(7, WireType.LengthDelimited)
-                .string(message.ty_type.bytearray);
+            writer.tag(7, WireType.LengthDelimited).string(message.ty_type.bytearray);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1170,25 +758,19 @@ class Member$Type extends MessageType<Member> {
         super("types.Member", [
             { no: 1, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "ty", kind: "message", T: () => Ty },
-            { no: 3, name: "key", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 3, name: "key", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<Member>): Member {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.name = "";
         message.key = false;
         if (value !== undefined)
             reflectionMergePartial<Member>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Member
-    ): Member {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Member): Member {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1196,12 +778,7 @@ class Member$Type extends MessageType<Member> {
                     message.name = reader.string();
                     break;
                 case /* types.Ty ty */ 2:
-                    message.ty = Ty.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.ty
-                    );
+                    message.ty = Ty.internalBinaryRead(reader, reader.uint32(), options, message.ty);
                     break;
                 case /* bool key */ 3:
                     message.key = reader.bool();
@@ -1209,47 +786,27 @@ class Member$Type extends MessageType<Member> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Member,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Member, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string name = 1; */
         if (message.name !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.name);
         /* types.Ty ty = 2; */
         if (message.ty)
-            Ty.internalBinaryWrite(
-                message.ty,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Ty.internalBinaryWrite(message.ty, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         /* bool key = 3; */
         if (message.key !== false)
             writer.tag(3, WireType.Varint).bool(message.key);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }

--- a/packages/grpc/src/generated/types.ts
+++ b/packages/grpc/src/generated/types.ts
@@ -173,38 +173,33 @@ export interface Clause {
     /**
      * @generated from protobuf oneof: clause_type
      */
-    clause_type:
-        | {
-              oneofKind: "hashed_keys";
-              /**
-               * @generated from protobuf field: types.HashedKeysClause hashed_keys = 1
-               */
-              hashed_keys: HashedKeysClause;
-          }
-        | {
-              oneofKind: "keys";
-              /**
-               * @generated from protobuf field: types.KeysClause keys = 2
-               */
-              keys: KeysClause;
-          }
-        | {
-              oneofKind: "member";
-              /**
-               * @generated from protobuf field: types.MemberClause member = 3
-               */
-              member: MemberClause;
-          }
-        | {
-              oneofKind: "composite";
-              /**
-               * @generated from protobuf field: types.CompositeClause composite = 4
-               */
-              composite: CompositeClause;
-          }
-        | {
-              oneofKind: undefined;
-          };
+    clause_type: {
+        oneofKind: "hashed_keys";
+        /**
+         * @generated from protobuf field: types.HashedKeysClause hashed_keys = 1
+         */
+        hashed_keys: HashedKeysClause;
+    } | {
+        oneofKind: "keys";
+        /**
+         * @generated from protobuf field: types.KeysClause keys = 2
+         */
+        keys: KeysClause;
+    } | {
+        oneofKind: "member";
+        /**
+         * @generated from protobuf field: types.MemberClause member = 3
+         */
+        member: MemberClause;
+    } | {
+        oneofKind: "composite";
+        /**
+         * @generated from protobuf field: types.CompositeClause composite = 4
+         */
+        composite: CompositeClause;
+    } | {
+        oneofKind: undefined;
+    };
 }
 /**
  * @generated from protobuf message types.KeysClause
@@ -239,31 +234,27 @@ export interface MemberValue {
     /**
      * @generated from protobuf oneof: value_type
      */
-    value_type:
-        | {
-              oneofKind: "primitive";
-              /**
-               * @generated from protobuf field: types.Primitive primitive = 1
-               */
-              primitive: Primitive;
-          }
-        | {
-              oneofKind: "string";
-              /**
-               * @generated from protobuf field: string string = 2
-               */
-              string: string;
-          }
-        | {
-              oneofKind: "list";
-              /**
-               * @generated from protobuf field: types.MemberValueList list = 3
-               */
-              list: MemberValueList;
-          }
-        | {
-              oneofKind: undefined;
-          };
+    value_type: {
+        oneofKind: "primitive";
+        /**
+         * @generated from protobuf field: types.Primitive primitive = 1
+         */
+        primitive: Primitive;
+    } | {
+        oneofKind: "string";
+        /**
+         * @generated from protobuf field: string string = 2
+         */
+        string: string;
+    } | {
+        oneofKind: "list";
+        /**
+         * @generated from protobuf field: types.MemberValueList list = 3
+         */
+        list: MemberValueList;
+    } | {
+        oneofKind: undefined;
+    };
 }
 /**
  * @generated from protobuf message types.MemberValueList
@@ -696,7 +687,7 @@ export enum PatternMatching {
     /**
      * @generated from protobuf enum value: VariableLen = 1;
      */
-    VariableLen = 1,
+    VariableLen = 1
 }
 /**
  * @generated from protobuf enum types.LogicalOperator
@@ -709,7 +700,7 @@ export enum LogicalOperator {
     /**
      * @generated from protobuf enum value: OR = 1;
      */
-    OR = 1,
+    OR = 1
 }
 /**
  * @generated from protobuf enum types.ComparisonOperator
@@ -746,7 +737,7 @@ export enum ComparisonOperator {
     /**
      * @generated from protobuf enum value: NOT_IN = 7;
      */
-    NOT_IN = 7,
+    NOT_IN = 7
 }
 /**
  * @generated from protobuf enum types.OrderDirection
@@ -759,7 +750,7 @@ export enum OrderDirection {
     /**
      * @generated from protobuf enum value: DESC = 1;
      */
-    DESC = 1,
+    DESC = 1
 }
 /**
  * @generated from protobuf enum types.PaginationDirection
@@ -772,7 +763,7 @@ export enum PaginationDirection {
     /**
      * @generated from protobuf enum value: BACKWARD = 1;
      */
-    BACKWARD = 1,
+    BACKWARD = 1
 }
 /**
  * @generated from protobuf enum types.CallType
@@ -785,44 +776,26 @@ export enum CallType {
     /**
      * @generated from protobuf enum value: EXECUTE_FROM_OUTSIDE = 1;
      */
-    EXECUTE_FROM_OUTSIDE = 1,
+    EXECUTE_FROM_OUTSIDE = 1
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class World$Type extends MessageType<World> {
     constructor() {
         super("types.World", [
-            {
-                no: 1,
-                name: "world_address",
-                kind: "scalar",
-                localName: "world_address",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "models",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Model,
-            },
+            { no: 1, name: "world_address", kind: "scalar", localName: "world_address", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "models", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Model }
         ]);
     }
     create(value?: PartialMessage<World>): World {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.world_address = "";
         message.models = [];
         if (value !== undefined)
             reflectionMergePartial<World>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: World
-    ): World {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: World): World {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -830,57 +803,29 @@ class World$Type extends MessageType<World> {
                     message.world_address = reader.string();
                     break;
                 case /* repeated types.Model models */ 2:
-                    message.models.push(
-                        Model.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.models.push(Model.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: World,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: World, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string world_address = 1; */
         if (message.world_address !== "")
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .string(message.world_address);
+            writer.tag(1, WireType.LengthDelimited).string(message.world_address);
         /* repeated types.Model models = 2; */
         for (let i = 0; i < message.models.length; i++)
-            Model.internalBinaryWrite(
-                message.models[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Model.internalBinaryWrite(message.models[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -892,63 +837,19 @@ export const World = new World$Type();
 class Model$Type extends MessageType<Model> {
     constructor() {
         super("types.Model", [
-            {
-                no: 1,
-                name: "selector",
-                kind: "scalar",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "namespace",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
+            { no: 1, name: "selector", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "namespace", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            {
-                no: 4,
-                name: "packed_size",
-                kind: "scalar",
-                localName: "packed_size",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 5,
-                name: "unpacked_size",
-                kind: "scalar",
-                localName: "unpacked_size",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 6,
-                name: "class_hash",
-                kind: "scalar",
-                localName: "class_hash",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 7,
-                name: "layout",
-                kind: "scalar",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 8,
-                name: "schema",
-                kind: "scalar",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 9,
-                name: "contract_address",
-                kind: "scalar",
-                localName: "contract_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 4, name: "packed_size", kind: "scalar", localName: "packed_size", T: 13 /*ScalarType.UINT32*/ },
+            { no: 5, name: "unpacked_size", kind: "scalar", localName: "unpacked_size", T: 13 /*ScalarType.UINT32*/ },
+            { no: 6, name: "class_hash", kind: "scalar", localName: "class_hash", T: 12 /*ScalarType.BYTES*/ },
+            { no: 7, name: "layout", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 8, name: "schema", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 9, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<Model>): Model {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.selector = new Uint8Array(0);
         message.namespace = "";
         message.name = "";
@@ -962,14 +863,8 @@ class Model$Type extends MessageType<Model> {
             reflectionMergePartial<Model>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Model
-    ): Model {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Model): Model {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1003,27 +898,15 @@ class Model$Type extends MessageType<Model> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Model,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Model, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes selector = 1; */
         if (message.selector.length)
             writer.tag(1, WireType.LengthDelimited).bytes(message.selector);
@@ -1050,16 +933,10 @@ class Model$Type extends MessageType<Model> {
             writer.tag(8, WireType.LengthDelimited).bytes(message.schema);
         /* bytes contract_address = 9; */
         if (message.contract_address.length)
-            writer
-                .tag(9, WireType.LengthDelimited)
-                .bytes(message.contract_address);
+            writer.tag(9, WireType.LengthDelimited).bytes(message.contract_address);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1071,38 +948,20 @@ export const Model = new Model$Type();
 class Entity$Type extends MessageType<Entity> {
     constructor() {
         super("types.Entity", [
-            {
-                no: 1,
-                name: "hashed_keys",
-                kind: "scalar",
-                localName: "hashed_keys",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "models",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Struct,
-            },
+            { no: 1, name: "hashed_keys", kind: "scalar", localName: "hashed_keys", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "models", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Struct }
         ]);
     }
     create(value?: PartialMessage<Entity>): Entity {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.hashed_keys = new Uint8Array(0);
         message.models = [];
         if (value !== undefined)
             reflectionMergePartial<Entity>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Entity
-    ): Entity {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Entity): Entity {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1110,55 +969,29 @@ class Entity$Type extends MessageType<Entity> {
                     message.hashed_keys = reader.bytes();
                     break;
                 case /* repeated types.Struct models */ 2:
-                    message.models.push(
-                        Struct.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.models.push(Struct.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Entity,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Entity, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes hashed_keys = 1; */
         if (message.hashed_keys.length)
             writer.tag(1, WireType.LengthDelimited).bytes(message.hashed_keys);
         /* repeated types.Struct models = 2; */
         for (let i = 0; i < message.models.length; i++)
-            Struct.internalBinaryWrite(
-                message.models[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Struct.internalBinaryWrite(message.models[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1170,31 +1003,13 @@ export const Entity = new Entity$Type();
 class Event$Type extends MessageType<Event> {
     constructor() {
         super("types.Event", [
-            {
-                no: 1,
-                name: "keys",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "data",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "transaction_hash",
-                kind: "scalar",
-                localName: "transaction_hash",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "keys", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "data", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "transaction_hash", kind: "scalar", localName: "transaction_hash", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<Event>): Event {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.keys = [];
         message.data = [];
         message.transaction_hash = new Uint8Array(0);
@@ -1202,14 +1017,8 @@ class Event$Type extends MessageType<Event> {
             reflectionMergePartial<Event>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Event
-    ): Event {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Event): Event {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1225,27 +1034,15 @@ class Event$Type extends MessageType<Event> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Event,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Event, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes keys = 1; */
         for (let i = 0; i < message.keys.length; i++)
             writer.tag(1, WireType.LengthDelimited).bytes(message.keys[i]);
@@ -1254,16 +1051,10 @@ class Event$Type extends MessageType<Event> {
             writer.tag(2, WireType.LengthDelimited).bytes(message.data[i]);
         /* bytes transaction_hash = 3; */
         if (message.transaction_hash.length)
-            writer
-                .tag(3, WireType.LengthDelimited)
-                .bytes(message.transaction_hash);
+            writer.tag(3, WireType.LengthDelimited).bytes(message.transaction_hash);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1276,31 +1067,14 @@ class Query$Type extends MessageType<Query> {
     constructor() {
         super("types.Query", [
             { no: 1, name: "clause", kind: "message", T: () => Clause },
-            {
-                no: 2,
-                name: "no_hashed_keys",
-                kind: "scalar",
-                localName: "no_hashed_keys",
-                T: 8 /*ScalarType.BOOL*/,
-            },
-            {
-                no: 3,
-                name: "models",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 9 /*ScalarType.STRING*/,
-            },
+            { no: 2, name: "no_hashed_keys", kind: "scalar", localName: "no_hashed_keys", T: 8 /*ScalarType.BOOL*/ },
+            { no: 3, name: "models", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "pagination", kind: "message", T: () => Pagination },
-            {
-                no: 5,
-                name: "historical",
-                kind: "scalar",
-                T: 8 /*ScalarType.BOOL*/,
-            },
+            { no: 5, name: "historical", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<Query>): Query {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.no_hashed_keys = false;
         message.models = [];
         message.historical = false;
@@ -1308,24 +1082,13 @@ class Query$Type extends MessageType<Query> {
             reflectionMergePartial<Query>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Query
-    ): Query {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Query): Query {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Clause clause */ 1:
-                    message.clause = Clause.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.clause
-                    );
+                    message.clause = Clause.internalBinaryRead(reader, reader.uint32(), options, message.clause);
                     break;
                 case /* bool no_hashed_keys */ 2:
                     message.no_hashed_keys = reader.bool();
@@ -1334,12 +1097,7 @@ class Query$Type extends MessageType<Query> {
                     message.models.push(reader.string());
                     break;
                 case /* types.Pagination pagination */ 4:
-                    message.pagination = Pagination.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.pagination
-                    );
+                    message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
                     break;
                 case /* bool historical */ 5:
                     message.historical = reader.bool();
@@ -1347,34 +1105,18 @@ class Query$Type extends MessageType<Query> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Query,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Query, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Clause clause = 1; */
         if (message.clause)
-            Clause.internalBinaryWrite(
-                message.clause,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Clause.internalBinaryWrite(message.clause, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         /* bool no_hashed_keys = 2; */
         if (message.no_hashed_keys !== false)
             writer.tag(2, WireType.Varint).bool(message.no_hashed_keys);
@@ -1383,21 +1125,13 @@ class Query$Type extends MessageType<Query> {
             writer.tag(3, WireType.LengthDelimited).string(message.models[i]);
         /* types.Pagination pagination = 4; */
         if (message.pagination)
-            Pagination.internalBinaryWrite(
-                message.pagination,
-                writer.tag(4, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         /* bool historical = 5; */
         if (message.historical !== false)
             writer.tag(5, WireType.Varint).bool(message.historical);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1410,87 +1144,47 @@ class EventQuery$Type extends MessageType<EventQuery> {
     constructor() {
         super("types.EventQuery", [
             { no: 1, name: "keys", kind: "message", T: () => KeysClause },
-            { no: 2, name: "pagination", kind: "message", T: () => Pagination },
+            { no: 2, name: "pagination", kind: "message", T: () => Pagination }
         ]);
     }
     create(value?: PartialMessage<EventQuery>): EventQuery {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
             reflectionMergePartial<EventQuery>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: EventQuery
-    ): EventQuery {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EventQuery): EventQuery {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.KeysClause keys */ 1:
-                    message.keys = KeysClause.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.keys
-                    );
+                    message.keys = KeysClause.internalBinaryRead(reader, reader.uint32(), options, message.keys);
                     break;
                 case /* types.Pagination pagination */ 2:
-                    message.pagination = Pagination.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.pagination
-                    );
+                    message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: EventQuery,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: EventQuery, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.KeysClause keys = 1; */
         if (message.keys)
-            KeysClause.internalBinaryWrite(
-                message.keys,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            KeysClause.internalBinaryWrite(message.keys, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         /* types.Pagination pagination = 2; */
         if (message.pagination)
-            Pagination.internalBinaryWrite(
-                message.pagination,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1502,158 +1196,75 @@ export const EventQuery = new EventQuery$Type();
 class Clause$Type extends MessageType<Clause> {
     constructor() {
         super("types.Clause", [
-            {
-                no: 1,
-                name: "hashed_keys",
-                kind: "message",
-                localName: "hashed_keys",
-                oneof: "clause_type",
-                T: () => HashedKeysClause,
-            },
-            {
-                no: 2,
-                name: "keys",
-                kind: "message",
-                oneof: "clause_type",
-                T: () => KeysClause,
-            },
-            {
-                no: 3,
-                name: "member",
-                kind: "message",
-                oneof: "clause_type",
-                T: () => MemberClause,
-            },
-            {
-                no: 4,
-                name: "composite",
-                kind: "message",
-                oneof: "clause_type",
-                T: () => CompositeClause,
-            },
+            { no: 1, name: "hashed_keys", kind: "message", localName: "hashed_keys", oneof: "clause_type", T: () => HashedKeysClause },
+            { no: 2, name: "keys", kind: "message", oneof: "clause_type", T: () => KeysClause },
+            { no: 3, name: "member", kind: "message", oneof: "clause_type", T: () => MemberClause },
+            { no: 4, name: "composite", kind: "message", oneof: "clause_type", T: () => CompositeClause }
         ]);
     }
     create(value?: PartialMessage<Clause>): Clause {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.clause_type = { oneofKind: undefined };
         if (value !== undefined)
             reflectionMergePartial<Clause>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Clause
-    ): Clause {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Clause): Clause {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.HashedKeysClause hashed_keys */ 1:
                     message.clause_type = {
                         oneofKind: "hashed_keys",
-                        hashed_keys: HashedKeysClause.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.clause_type as any).hashed_keys
-                        ),
+                        hashed_keys: HashedKeysClause.internalBinaryRead(reader, reader.uint32(), options, (message.clause_type as any).hashed_keys)
                     };
                     break;
                 case /* types.KeysClause keys */ 2:
                     message.clause_type = {
                         oneofKind: "keys",
-                        keys: KeysClause.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.clause_type as any).keys
-                        ),
+                        keys: KeysClause.internalBinaryRead(reader, reader.uint32(), options, (message.clause_type as any).keys)
                     };
                     break;
                 case /* types.MemberClause member */ 3:
                     message.clause_type = {
                         oneofKind: "member",
-                        member: MemberClause.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.clause_type as any).member
-                        ),
+                        member: MemberClause.internalBinaryRead(reader, reader.uint32(), options, (message.clause_type as any).member)
                     };
                     break;
                 case /* types.CompositeClause composite */ 4:
                     message.clause_type = {
                         oneofKind: "composite",
-                        composite: CompositeClause.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.clause_type as any).composite
-                        ),
+                        composite: CompositeClause.internalBinaryRead(reader, reader.uint32(), options, (message.clause_type as any).composite)
                     };
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Clause,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Clause, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.HashedKeysClause hashed_keys = 1; */
         if (message.clause_type.oneofKind === "hashed_keys")
-            HashedKeysClause.internalBinaryWrite(
-                message.clause_type.hashed_keys,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            HashedKeysClause.internalBinaryWrite(message.clause_type.hashed_keys, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         /* types.KeysClause keys = 2; */
         if (message.clause_type.oneofKind === "keys")
-            KeysClause.internalBinaryWrite(
-                message.clause_type.keys,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            KeysClause.internalBinaryWrite(message.clause_type.keys, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         /* types.MemberClause member = 3; */
         if (message.clause_type.oneofKind === "member")
-            MemberClause.internalBinaryWrite(
-                message.clause_type.member,
-                writer.tag(3, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            MemberClause.internalBinaryWrite(message.clause_type.member, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         /* types.CompositeClause composite = 4; */
         if (message.clause_type.oneofKind === "composite")
-            CompositeClause.internalBinaryWrite(
-                message.clause_type.composite,
-                writer.tag(4, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            CompositeClause.internalBinaryWrite(message.clause_type.composite, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1665,31 +1276,13 @@ export const Clause = new Clause$Type();
 class KeysClause$Type extends MessageType<KeysClause> {
     constructor() {
         super("types.KeysClause", [
-            {
-                no: 2,
-                name: "keys",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "pattern_matching",
-                kind: "enum",
-                localName: "pattern_matching",
-                T: () => ["types.PatternMatching", PatternMatching],
-            },
-            {
-                no: 4,
-                name: "models",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 9 /*ScalarType.STRING*/,
-            },
+            { no: 2, name: "keys", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "pattern_matching", kind: "enum", localName: "pattern_matching", T: () => ["types.PatternMatching", PatternMatching] },
+            { no: 4, name: "models", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<KeysClause>): KeysClause {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.keys = [];
         message.pattern_matching = 0;
         message.models = [];
@@ -1697,14 +1290,8 @@ class KeysClause$Type extends MessageType<KeysClause> {
             reflectionMergePartial<KeysClause>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: KeysClause
-    ): KeysClause {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: KeysClause): KeysClause {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1720,27 +1307,15 @@ class KeysClause$Type extends MessageType<KeysClause> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: KeysClause,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: KeysClause, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes keys = 2; */
         for (let i = 0; i < message.keys.length; i++)
             writer.tag(2, WireType.LengthDelimited).bytes(message.keys[i]);
@@ -1752,11 +1327,7 @@ class KeysClause$Type extends MessageType<KeysClause> {
             writer.tag(4, WireType.LengthDelimited).string(message.models[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1768,31 +1339,18 @@ export const KeysClause = new KeysClause$Type();
 class HashedKeysClause$Type extends MessageType<HashedKeysClause> {
     constructor() {
         super("types.HashedKeysClause", [
-            {
-                no: 1,
-                name: "hashed_keys",
-                kind: "scalar",
-                localName: "hashed_keys",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "hashed_keys", kind: "scalar", localName: "hashed_keys", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<HashedKeysClause>): HashedKeysClause {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.hashed_keys = [];
         if (value !== undefined)
             reflectionMergePartial<HashedKeysClause>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: HashedKeysClause
-    ): HashedKeysClause {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: HashedKeysClause): HashedKeysClause {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1802,39 +1360,21 @@ class HashedKeysClause$Type extends MessageType<HashedKeysClause> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: HashedKeysClause,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: HashedKeysClause, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes hashed_keys = 1; */
         for (let i = 0; i < message.hashed_keys.length; i++)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.hashed_keys[i]);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.hashed_keys[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1846,125 +1386,65 @@ export const HashedKeysClause = new HashedKeysClause$Type();
 class MemberValue$Type extends MessageType<MemberValue> {
     constructor() {
         super("types.MemberValue", [
-            {
-                no: 1,
-                name: "primitive",
-                kind: "message",
-                oneof: "value_type",
-                T: () => Primitive,
-            },
-            {
-                no: 2,
-                name: "string",
-                kind: "scalar",
-                oneof: "value_type",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 3,
-                name: "list",
-                kind: "message",
-                oneof: "value_type",
-                T: () => MemberValueList,
-            },
+            { no: 1, name: "primitive", kind: "message", oneof: "value_type", T: () => Primitive },
+            { no: 2, name: "string", kind: "scalar", oneof: "value_type", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "list", kind: "message", oneof: "value_type", T: () => MemberValueList }
         ]);
     }
     create(value?: PartialMessage<MemberValue>): MemberValue {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.value_type = { oneofKind: undefined };
         if (value !== undefined)
             reflectionMergePartial<MemberValue>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: MemberValue
-    ): MemberValue {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: MemberValue): MemberValue {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Primitive primitive */ 1:
                     message.value_type = {
                         oneofKind: "primitive",
-                        primitive: Primitive.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.value_type as any).primitive
-                        ),
+                        primitive: Primitive.internalBinaryRead(reader, reader.uint32(), options, (message.value_type as any).primitive)
                     };
                     break;
                 case /* string string */ 2:
                     message.value_type = {
                         oneofKind: "string",
-                        string: reader.string(),
+                        string: reader.string()
                     };
                     break;
                 case /* types.MemberValueList list */ 3:
                     message.value_type = {
                         oneofKind: "list",
-                        list: MemberValueList.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options,
-                            (message.value_type as any).list
-                        ),
+                        list: MemberValueList.internalBinaryRead(reader, reader.uint32(), options, (message.value_type as any).list)
                     };
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: MemberValue,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: MemberValue, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Primitive primitive = 1; */
         if (message.value_type.oneofKind === "primitive")
-            Primitive.internalBinaryWrite(
-                message.value_type.primitive,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Primitive.internalBinaryWrite(message.value_type.primitive, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         /* string string = 2; */
         if (message.value_type.oneofKind === "string")
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .string(message.value_type.string);
+            writer.tag(2, WireType.LengthDelimited).string(message.value_type.string);
         /* types.MemberValueList list = 3; */
         if (message.value_type.oneofKind === "list")
-            MemberValueList.internalBinaryWrite(
-                message.value_type.list,
-                writer.tag(3, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            MemberValueList.internalBinaryWrite(message.value_type.list, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1976,80 +1456,42 @@ export const MemberValue = new MemberValue$Type();
 class MemberValueList$Type extends MessageType<MemberValueList> {
     constructor() {
         super("types.MemberValueList", [
-            {
-                no: 1,
-                name: "values",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => MemberValue,
-            },
+            { no: 1, name: "values", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => MemberValue }
         ]);
     }
     create(value?: PartialMessage<MemberValueList>): MemberValueList {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.values = [];
         if (value !== undefined)
             reflectionMergePartial<MemberValueList>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: MemberValueList
-    ): MemberValueList {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: MemberValueList): MemberValueList {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* repeated types.MemberValue values */ 1:
-                    message.values.push(
-                        MemberValue.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.values.push(MemberValue.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: MemberValueList,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: MemberValueList, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated types.MemberValue values = 1; */
         for (let i = 0; i < message.values.length; i++)
-            MemberValue.internalBinaryWrite(
-                message.values[i],
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            MemberValue.internalBinaryWrite(message.values[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2061,29 +1503,14 @@ export const MemberValueList = new MemberValueList$Type();
 class MemberClause$Type extends MessageType<MemberClause> {
     constructor() {
         super("types.MemberClause", [
-            {
-                no: 2,
-                name: "model",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 3,
-                name: "member",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 4,
-                name: "operator",
-                kind: "enum",
-                T: () => ["types.ComparisonOperator", ComparisonOperator],
-            },
-            { no: 5, name: "value", kind: "message", T: () => MemberValue },
+            { no: 2, name: "model", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "member", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "operator", kind: "enum", T: () => ["types.ComparisonOperator", ComparisonOperator] },
+            { no: 5, name: "value", kind: "message", T: () => MemberValue }
         ]);
     }
     create(value?: PartialMessage<MemberClause>): MemberClause {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.model = "";
         message.member = "";
         message.operator = 0;
@@ -2091,14 +1518,8 @@ class MemberClause$Type extends MessageType<MemberClause> {
             reflectionMergePartial<MemberClause>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: MemberClause
-    ): MemberClause {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: MemberClause): MemberClause {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2112,37 +1533,20 @@ class MemberClause$Type extends MessageType<MemberClause> {
                     message.operator = reader.int32();
                     break;
                 case /* types.MemberValue value */ 5:
-                    message.value = MemberValue.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.value
-                    );
+                    message.value = MemberValue.internalBinaryRead(reader, reader.uint32(), options, message.value);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: MemberClause,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: MemberClause, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string model = 2; */
         if (message.model !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.model);
@@ -2154,18 +1558,10 @@ class MemberClause$Type extends MessageType<MemberClause> {
             writer.tag(4, WireType.Varint).int32(message.operator);
         /* types.MemberValue value = 5; */
         if (message.value)
-            MemberValue.internalBinaryWrite(
-                message.value,
-                writer.tag(5, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            MemberValue.internalBinaryWrite(message.value, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2177,37 +1573,20 @@ export const MemberClause = new MemberClause$Type();
 class CompositeClause$Type extends MessageType<CompositeClause> {
     constructor() {
         super("types.CompositeClause", [
-            {
-                no: 3,
-                name: "operator",
-                kind: "enum",
-                T: () => ["types.LogicalOperator", LogicalOperator],
-            },
-            {
-                no: 4,
-                name: "clauses",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Clause,
-            },
+            { no: 3, name: "operator", kind: "enum", T: () => ["types.LogicalOperator", LogicalOperator] },
+            { no: 4, name: "clauses", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Clause }
         ]);
     }
     create(value?: PartialMessage<CompositeClause>): CompositeClause {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.operator = 0;
         message.clauses = [];
         if (value !== undefined)
             reflectionMergePartial<CompositeClause>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: CompositeClause
-    ): CompositeClause {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: CompositeClause): CompositeClause {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2215,55 +1594,29 @@ class CompositeClause$Type extends MessageType<CompositeClause> {
                     message.operator = reader.int32();
                     break;
                 case /* repeated types.Clause clauses */ 4:
-                    message.clauses.push(
-                        Clause.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.clauses.push(Clause.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: CompositeClause,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: CompositeClause, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.LogicalOperator operator = 3; */
         if (message.operator !== 0)
             writer.tag(3, WireType.Varint).int32(message.operator);
         /* repeated types.Clause clauses = 4; */
         for (let i = 0; i < message.clauses.length; i++)
-            Clause.internalBinaryWrite(
-                message.clauses[i],
-                writer.tag(4, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Clause.internalBinaryWrite(message.clauses[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2275,44 +1628,16 @@ export const CompositeClause = new CompositeClause$Type();
 class Token$Type extends MessageType<Token> {
     constructor() {
         super("types.Token", [
-            {
-                no: 1,
-                name: "token_id",
-                kind: "scalar",
-                localName: "token_id",
-                opt: true,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "contract_address",
-                kind: "scalar",
-                localName: "contract_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "token_id", kind: "scalar", localName: "token_id", opt: true, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            {
-                no: 4,
-                name: "symbol",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 5,
-                name: "decimals",
-                kind: "scalar",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 6,
-                name: "metadata",
-                kind: "scalar",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 4, name: "symbol", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "decimals", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 6, name: "metadata", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<Token>): Token {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.contract_address = new Uint8Array(0);
         message.name = "";
         message.symbol = "";
@@ -2322,14 +1647,8 @@ class Token$Type extends MessageType<Token> {
             reflectionMergePartial<Token>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Token
-    ): Token {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Token): Token {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2354,35 +1673,21 @@ class Token$Type extends MessageType<Token> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Token,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Token, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* optional bytes token_id = 1; */
         if (message.token_id !== undefined)
             writer.tag(1, WireType.LengthDelimited).bytes(message.token_id);
         /* bytes contract_address = 2; */
         if (message.contract_address.length)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.contract_address);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_address);
         /* string name = 3; */
         if (message.name !== "")
             writer.tag(3, WireType.LengthDelimited).string(message.name);
@@ -2397,11 +1702,7 @@ class Token$Type extends MessageType<Token> {
             writer.tag(6, WireType.LengthDelimited).bytes(message.metadata);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2413,42 +1714,16 @@ export const Token = new Token$Type();
 class TokenCollection$Type extends MessageType<TokenCollection> {
     constructor() {
         super("types.TokenCollection", [
-            {
-                no: 2,
-                name: "contract_address",
-                kind: "scalar",
-                localName: "contract_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 2, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
             { no: 3, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            {
-                no: 4,
-                name: "symbol",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 5,
-                name: "decimals",
-                kind: "scalar",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 6,
-                name: "count",
-                kind: "scalar",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 7,
-                name: "metadata",
-                kind: "scalar",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 4, name: "symbol", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "decimals", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 6, name: "count", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 7, name: "metadata", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<TokenCollection>): TokenCollection {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.contract_address = new Uint8Array(0);
         message.name = "";
         message.symbol = "";
@@ -2459,14 +1734,8 @@ class TokenCollection$Type extends MessageType<TokenCollection> {
             reflectionMergePartial<TokenCollection>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: TokenCollection
-    ): TokenCollection {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenCollection): TokenCollection {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2491,32 +1760,18 @@ class TokenCollection$Type extends MessageType<TokenCollection> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: TokenCollection,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: TokenCollection, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes contract_address = 2; */
         if (message.contract_address.length)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.contract_address);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_address);
         /* string name = 3; */
         if (message.name !== "")
             writer.tag(3, WireType.LengthDelimited).string(message.name);
@@ -2534,11 +1789,7 @@ class TokenCollection$Type extends MessageType<TokenCollection> {
             writer.tag(7, WireType.LengthDelimited).bytes(message.metadata);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2550,38 +1801,14 @@ export const TokenCollection = new TokenCollection$Type();
 class TokenBalance$Type extends MessageType<TokenBalance> {
     constructor() {
         super("types.TokenBalance", [
-            {
-                no: 1,
-                name: "balance",
-                kind: "scalar",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "account_address",
-                kind: "scalar",
-                localName: "account_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "contract_address",
-                kind: "scalar",
-                localName: "contract_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 4,
-                name: "token_id",
-                kind: "scalar",
-                localName: "token_id",
-                opt: true,
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "balance", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "account_address", kind: "scalar", localName: "account_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "token_id", kind: "scalar", localName: "token_id", opt: true, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<TokenBalance>): TokenBalance {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.balance = new Uint8Array(0);
         message.account_address = new Uint8Array(0);
         message.contract_address = new Uint8Array(0);
@@ -2589,14 +1816,8 @@ class TokenBalance$Type extends MessageType<TokenBalance> {
             reflectionMergePartial<TokenBalance>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: TokenBalance
-    ): TokenBalance {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenBalance): TokenBalance {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2615,50 +1836,30 @@ class TokenBalance$Type extends MessageType<TokenBalance> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: TokenBalance,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: TokenBalance, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes balance = 1; */
         if (message.balance.length)
             writer.tag(1, WireType.LengthDelimited).bytes(message.balance);
         /* bytes account_address = 2; */
         if (message.account_address.length)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.account_address);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.account_address);
         /* bytes contract_address = 3; */
         if (message.contract_address.length)
-            writer
-                .tag(3, WireType.LengthDelimited)
-                .bytes(message.contract_address);
+            writer.tag(3, WireType.LengthDelimited).bytes(message.contract_address);
         /* optional bytes token_id = 4; */
         if (message.token_id !== undefined)
             writer.tag(4, WireType.LengthDelimited).bytes(message.token_id);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2670,36 +1871,20 @@ export const TokenBalance = new TokenBalance$Type();
 class OrderBy$Type extends MessageType<OrderBy> {
     constructor() {
         super("types.OrderBy", [
-            {
-                no: 1,
-                name: "field",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "direction",
-                kind: "enum",
-                T: () => ["types.OrderDirection", OrderDirection],
-            },
+            { no: 1, name: "field", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "direction", kind: "enum", T: () => ["types.OrderDirection", OrderDirection] }
         ]);
     }
     create(value?: PartialMessage<OrderBy>): OrderBy {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.field = "";
         message.direction = 0;
         if (value !== undefined)
             reflectionMergePartial<OrderBy>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: OrderBy
-    ): OrderBy {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: OrderBy): OrderBy {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2712,27 +1897,15 @@ class OrderBy$Type extends MessageType<OrderBy> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: OrderBy,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: OrderBy, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string field = 1; */
         if (message.field !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.field);
@@ -2741,11 +1914,7 @@ class OrderBy$Type extends MessageType<OrderBy> {
             writer.tag(2, WireType.Varint).int32(message.direction);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2757,30 +1926,13 @@ export const OrderBy = new OrderBy$Type();
 class Controller$Type extends MessageType<Controller> {
     constructor() {
         super("types.Controller", [
-            {
-                no: 1,
-                name: "address",
-                kind: "scalar",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "username",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 3,
-                name: "deployed_at_timestamp",
-                kind: "scalar",
-                localName: "deployed_at_timestamp",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
+            { no: 1, name: "address", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "username", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "deployed_at_timestamp", kind: "scalar", localName: "deployed_at_timestamp", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<Controller>): Controller {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.address = new Uint8Array(0);
         message.username = "";
         message.deployed_at_timestamp = 0n;
@@ -2788,14 +1940,8 @@ class Controller$Type extends MessageType<Controller> {
             reflectionMergePartial<Controller>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Controller
-    ): Controller {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Controller): Controller {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2811,27 +1957,15 @@ class Controller$Type extends MessageType<Controller> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Controller,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Controller, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes address = 1; */
         if (message.address.length)
             writer.tag(1, WireType.LengthDelimited).bytes(message.address);
@@ -2840,16 +1974,10 @@ class Controller$Type extends MessageType<Controller> {
             writer.tag(2, WireType.LengthDelimited).string(message.username);
         /* uint64 deployed_at_timestamp = 3; */
         if (message.deployed_at_timestamp !== 0n)
-            writer
-                .tag(3, WireType.Varint)
-                .uint64(message.deployed_at_timestamp);
+            writer.tag(3, WireType.Varint).uint64(message.deployed_at_timestamp);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2861,36 +1989,14 @@ export const Controller = new Controller$Type();
 class Pagination$Type extends MessageType<Pagination> {
     constructor() {
         super("types.Pagination", [
-            {
-                no: 1,
-                name: "cursor",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "limit",
-                kind: "scalar",
-                T: 13 /*ScalarType.UINT32*/,
-            },
-            {
-                no: 3,
-                name: "direction",
-                kind: "enum",
-                T: () => ["types.PaginationDirection", PaginationDirection],
-            },
-            {
-                no: 4,
-                name: "order_by",
-                kind: "message",
-                localName: "order_by",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => OrderBy,
-            },
+            { no: 1, name: "cursor", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "limit", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 3, name: "direction", kind: "enum", T: () => ["types.PaginationDirection", PaginationDirection] },
+            { no: 4, name: "order_by", kind: "message", localName: "order_by", repeat: 2 /*RepeatType.UNPACKED*/, T: () => OrderBy }
         ]);
     }
     create(value?: PartialMessage<Pagination>): Pagination {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.cursor = "";
         message.limit = 0;
         message.direction = 0;
@@ -2899,14 +2005,8 @@ class Pagination$Type extends MessageType<Pagination> {
             reflectionMergePartial<Pagination>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Pagination
-    ): Pagination {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Pagination): Pagination {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2920,38 +2020,20 @@ class Pagination$Type extends MessageType<Pagination> {
                     message.direction = reader.int32();
                     break;
                 case /* repeated types.OrderBy order_by */ 4:
-                    message.order_by.push(
-                        OrderBy.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.order_by.push(OrderBy.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Pagination,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Pagination, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string cursor = 1; */
         if (message.cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.cursor);
@@ -2963,18 +2045,10 @@ class Pagination$Type extends MessageType<Pagination> {
             writer.tag(3, WireType.Varint).int32(message.direction);
         /* repeated types.OrderBy order_by = 4; */
         for (let i = 0; i < message.order_by.length; i++)
-            OrderBy.internalBinaryWrite(
-                message.order_by[i],
-                writer.tag(4, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            OrderBy.internalBinaryWrite(message.order_by[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2986,40 +2060,21 @@ export const Pagination = new Pagination$Type();
 class ControllerQuery$Type extends MessageType<ControllerQuery> {
     constructor() {
         super("types.ControllerQuery", [
-            {
-                no: 1,
-                name: "contract_addresses",
-                kind: "scalar",
-                localName: "contract_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "usernames",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 9 /*ScalarType.STRING*/,
-            },
-            { no: 3, name: "pagination", kind: "message", T: () => Pagination },
+            { no: 1, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "usernames", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "pagination", kind: "message", T: () => Pagination }
         ]);
     }
     create(value?: PartialMessage<ControllerQuery>): ControllerQuery {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.contract_addresses = [];
         message.usernames = [];
         if (value !== undefined)
             reflectionMergePartial<ControllerQuery>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: ControllerQuery
-    ): ControllerQuery {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ControllerQuery): ControllerQuery {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3030,61 +2085,32 @@ class ControllerQuery$Type extends MessageType<ControllerQuery> {
                     message.usernames.push(reader.string());
                     break;
                 case /* types.Pagination pagination */ 3:
-                    message.pagination = Pagination.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.pagination
-                    );
+                    message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: ControllerQuery,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: ControllerQuery, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes contract_addresses = 1; */
         for (let i = 0; i < message.contract_addresses.length; i++)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.contract_addresses[i]);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
         /* repeated string usernames = 2; */
         for (let i = 0; i < message.usernames.length; i++)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .string(message.usernames[i]);
+            writer.tag(2, WireType.LengthDelimited).string(message.usernames[i]);
         /* types.Pagination pagination = 3; */
         if (message.pagination)
-            Pagination.internalBinaryWrite(
-                message.pagination,
-                writer.tag(3, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3096,41 +2122,21 @@ export const ControllerQuery = new ControllerQuery$Type();
 class TokenQuery$Type extends MessageType<TokenQuery> {
     constructor() {
         super("types.TokenQuery", [
-            {
-                no: 1,
-                name: "contract_addresses",
-                kind: "scalar",
-                localName: "contract_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "token_ids",
-                kind: "scalar",
-                localName: "token_ids",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            { no: 3, name: "pagination", kind: "message", T: () => Pagination },
+            { no: 1, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "pagination", kind: "message", T: () => Pagination }
         ]);
     }
     create(value?: PartialMessage<TokenQuery>): TokenQuery {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.contract_addresses = [];
         message.token_ids = [];
         if (value !== undefined)
             reflectionMergePartial<TokenQuery>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: TokenQuery
-    ): TokenQuery {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenQuery): TokenQuery {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3141,59 +2147,32 @@ class TokenQuery$Type extends MessageType<TokenQuery> {
                     message.token_ids.push(reader.bytes());
                     break;
                 case /* types.Pagination pagination */ 3:
-                    message.pagination = Pagination.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.pagination
-                    );
+                    message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: TokenQuery,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: TokenQuery, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes contract_addresses = 1; */
         for (let i = 0; i < message.contract_addresses.length; i++)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.contract_addresses[i]);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
         /* repeated bytes token_ids = 2; */
         for (let i = 0; i < message.token_ids.length; i++)
             writer.tag(2, WireType.LengthDelimited).bytes(message.token_ids[i]);
         /* types.Pagination pagination = 3; */
         if (message.pagination)
-            Pagination.internalBinaryWrite(
-                message.pagination,
-                writer.tag(3, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3205,35 +2184,14 @@ export const TokenQuery = new TokenQuery$Type();
 class TokenBalanceQuery$Type extends MessageType<TokenBalanceQuery> {
     constructor() {
         super("types.TokenBalanceQuery", [
-            {
-                no: 1,
-                name: "account_addresses",
-                kind: "scalar",
-                localName: "account_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "contract_addresses",
-                kind: "scalar",
-                localName: "contract_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "token_ids",
-                kind: "scalar",
-                localName: "token_ids",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            { no: 4, name: "pagination", kind: "message", T: () => Pagination },
+            { no: 1, name: "account_addresses", kind: "scalar", localName: "account_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "pagination", kind: "message", T: () => Pagination }
         ]);
     }
     create(value?: PartialMessage<TokenBalanceQuery>): TokenBalanceQuery {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.account_addresses = [];
         message.contract_addresses = [];
         message.token_ids = [];
@@ -3241,14 +2199,8 @@ class TokenBalanceQuery$Type extends MessageType<TokenBalanceQuery> {
             reflectionMergePartial<TokenBalanceQuery>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: TokenBalanceQuery
-    ): TokenBalanceQuery {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenBalanceQuery): TokenBalanceQuery {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3262,64 +2214,35 @@ class TokenBalanceQuery$Type extends MessageType<TokenBalanceQuery> {
                     message.token_ids.push(reader.bytes());
                     break;
                 case /* types.Pagination pagination */ 4:
-                    message.pagination = Pagination.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.pagination
-                    );
+                    message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: TokenBalanceQuery,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: TokenBalanceQuery, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes account_addresses = 1; */
         for (let i = 0; i < message.account_addresses.length; i++)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.account_addresses[i]);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.account_addresses[i]);
         /* repeated bytes contract_addresses = 2; */
         for (let i = 0; i < message.contract_addresses.length; i++)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.contract_addresses[i]);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
         /* repeated bytes token_ids = 3; */
         for (let i = 0; i < message.token_ids.length; i++)
             writer.tag(3, WireType.LengthDelimited).bytes(message.token_ids[i]);
         /* types.Pagination pagination = 4; */
         if (message.pagination)
-            Pagination.internalBinaryWrite(
-                message.pagination,
-                writer.tag(4, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3331,44 +2254,15 @@ export const TokenBalanceQuery = new TokenBalanceQuery$Type();
 class TransactionCall$Type extends MessageType<TransactionCall> {
     constructor() {
         super("types.TransactionCall", [
-            {
-                no: 1,
-                name: "contract_address",
-                kind: "scalar",
-                localName: "contract_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "entrypoint",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 3,
-                name: "calldata",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 4,
-                name: "call_type",
-                kind: "enum",
-                localName: "call_type",
-                T: () => ["types.CallType", CallType],
-            },
-            {
-                no: 5,
-                name: "caller_address",
-                kind: "scalar",
-                localName: "caller_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "entrypoint", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "calldata", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "call_type", kind: "enum", localName: "call_type", T: () => ["types.CallType", CallType] },
+            { no: 5, name: "caller_address", kind: "scalar", localName: "caller_address", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<TransactionCall>): TransactionCall {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.contract_address = new Uint8Array(0);
         message.entrypoint = "";
         message.calldata = [];
@@ -3378,14 +2272,8 @@ class TransactionCall$Type extends MessageType<TransactionCall> {
             reflectionMergePartial<TransactionCall>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: TransactionCall
-    ): TransactionCall {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TransactionCall): TransactionCall {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3407,32 +2295,18 @@ class TransactionCall$Type extends MessageType<TransactionCall> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: TransactionCall,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: TransactionCall, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes contract_address = 1; */
         if (message.contract_address.length)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.contract_address);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_address);
         /* string entrypoint = 2; */
         if (message.entrypoint !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.entrypoint);
@@ -3444,16 +2318,10 @@ class TransactionCall$Type extends MessageType<TransactionCall> {
             writer.tag(4, WireType.Varint).int32(message.call_type);
         /* bytes caller_address = 5; */
         if (message.caller_address.length)
-            writer
-                .tag(5, WireType.LengthDelimited)
-                .bytes(message.caller_address);
+            writer.tag(5, WireType.LengthDelimited).bytes(message.caller_address);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3465,89 +2333,21 @@ export const TransactionCall = new TransactionCall$Type();
 class Transaction$Type extends MessageType<Transaction> {
     constructor() {
         super("types.Transaction", [
-            {
-                no: 1,
-                name: "transaction_hash",
-                kind: "scalar",
-                localName: "transaction_hash",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "sender_address",
-                kind: "scalar",
-                localName: "sender_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "calldata",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 4,
-                name: "max_fee",
-                kind: "scalar",
-                localName: "max_fee",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 5,
-                name: "signature",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 6,
-                name: "nonce",
-                kind: "scalar",
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 7,
-                name: "block_number",
-                kind: "scalar",
-                localName: "block_number",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 8,
-                name: "transaction_type",
-                kind: "scalar",
-                localName: "transaction_type",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 9,
-                name: "block_timestamp",
-                kind: "scalar",
-                localName: "block_timestamp",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 10,
-                name: "calls",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => TransactionCall,
-            },
-            {
-                no: 11,
-                name: "unique_models",
-                kind: "scalar",
-                localName: "unique_models",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "transaction_hash", kind: "scalar", localName: "transaction_hash", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "sender_address", kind: "scalar", localName: "sender_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "calldata", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "max_fee", kind: "scalar", localName: "max_fee", T: 12 /*ScalarType.BYTES*/ },
+            { no: 5, name: "signature", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 6, name: "nonce", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 7, name: "block_number", kind: "scalar", localName: "block_number", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 8, name: "transaction_type", kind: "scalar", localName: "transaction_type", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "block_timestamp", kind: "scalar", localName: "block_timestamp", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 10, name: "calls", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => TransactionCall },
+            { no: 11, name: "unique_models", kind: "scalar", localName: "unique_models", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<Transaction>): Transaction {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.transaction_hash = new Uint8Array(0);
         message.sender_address = new Uint8Array(0);
         message.calldata = [];
@@ -3563,14 +2363,8 @@ class Transaction$Type extends MessageType<Transaction> {
             reflectionMergePartial<Transaction>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: Transaction
-    ): Transaction {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Transaction): Transaction {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3602,13 +2396,7 @@ class Transaction$Type extends MessageType<Transaction> {
                     message.block_timestamp = reader.uint64().toBigInt();
                     break;
                 case /* repeated types.TransactionCall calls */ 10:
-                    message.calls.push(
-                        TransactionCall.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.calls.push(TransactionCall.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 case /* repeated bytes unique_models */ 11:
                     message.unique_models.push(reader.bytes());
@@ -3616,37 +2404,21 @@ class Transaction$Type extends MessageType<Transaction> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: Transaction,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: Transaction, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes transaction_hash = 1; */
         if (message.transaction_hash.length)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.transaction_hash);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.transaction_hash);
         /* bytes sender_address = 2; */
         if (message.sender_address.length)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.sender_address);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.sender_address);
         /* repeated bytes calldata = 3; */
         for (let i = 0; i < message.calldata.length; i++)
             writer.tag(3, WireType.LengthDelimited).bytes(message.calldata[i]);
@@ -3664,31 +2436,19 @@ class Transaction$Type extends MessageType<Transaction> {
             writer.tag(7, WireType.Varint).uint64(message.block_number);
         /* string transaction_type = 8; */
         if (message.transaction_type !== "")
-            writer
-                .tag(8, WireType.LengthDelimited)
-                .string(message.transaction_type);
+            writer.tag(8, WireType.LengthDelimited).string(message.transaction_type);
         /* uint64 block_timestamp = 9; */
         if (message.block_timestamp !== 0n)
             writer.tag(9, WireType.Varint).uint64(message.block_timestamp);
         /* repeated types.TransactionCall calls = 10; */
         for (let i = 0; i < message.calls.length; i++)
-            TransactionCall.internalBinaryWrite(
-                message.calls[i],
-                writer.tag(10, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TransactionCall.internalBinaryWrite(message.calls[i], writer.tag(10, WireType.LengthDelimited).fork(), options).join();
         /* repeated bytes unique_models = 11; */
         for (let i = 0; i < message.unique_models.length; i++)
-            writer
-                .tag(11, WireType.LengthDelimited)
-                .bytes(message.unique_models[i]);
+            writer.tag(11, WireType.LengthDelimited).bytes(message.unique_models[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3700,67 +2460,17 @@ export const Transaction = new Transaction$Type();
 class TransactionFilter$Type extends MessageType<TransactionFilter> {
     constructor() {
         super("types.TransactionFilter", [
-            {
-                no: 1,
-                name: "transaction_hashes",
-                kind: "scalar",
-                localName: "transaction_hashes",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "caller_addresses",
-                kind: "scalar",
-                localName: "caller_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "contract_addresses",
-                kind: "scalar",
-                localName: "contract_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 4,
-                name: "entrypoints",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 5,
-                name: "model_selectors",
-                kind: "scalar",
-                localName: "model_selectors",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 6,
-                name: "from_block",
-                kind: "scalar",
-                localName: "from_block",
-                opt: true,
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 7,
-                name: "to_block",
-                kind: "scalar",
-                localName: "to_block",
-                opt: true,
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
+            { no: 1, name: "transaction_hashes", kind: "scalar", localName: "transaction_hashes", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "caller_addresses", kind: "scalar", localName: "caller_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "entrypoints", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "model_selectors", kind: "scalar", localName: "model_selectors", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 6, name: "from_block", kind: "scalar", localName: "from_block", opt: true, T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 7, name: "to_block", kind: "scalar", localName: "to_block", opt: true, T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<TransactionFilter>): TransactionFilter {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.transaction_hashes = [];
         message.caller_addresses = [];
         message.contract_addresses = [];
@@ -3770,14 +2480,8 @@ class TransactionFilter$Type extends MessageType<TransactionFilter> {
             reflectionMergePartial<TransactionFilter>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: TransactionFilter
-    ): TransactionFilter {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TransactionFilter): TransactionFilter {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3805,52 +2509,30 @@ class TransactionFilter$Type extends MessageType<TransactionFilter> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: TransactionFilter,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: TransactionFilter, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes transaction_hashes = 1; */
         for (let i = 0; i < message.transaction_hashes.length; i++)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.transaction_hashes[i]);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.transaction_hashes[i]);
         /* repeated bytes caller_addresses = 2; */
         for (let i = 0; i < message.caller_addresses.length; i++)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.caller_addresses[i]);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.caller_addresses[i]);
         /* repeated bytes contract_addresses = 3; */
         for (let i = 0; i < message.contract_addresses.length; i++)
-            writer
-                .tag(3, WireType.LengthDelimited)
-                .bytes(message.contract_addresses[i]);
+            writer.tag(3, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
         /* repeated string entrypoints = 4; */
         for (let i = 0; i < message.entrypoints.length; i++)
-            writer
-                .tag(4, WireType.LengthDelimited)
-                .string(message.entrypoints[i]);
+            writer.tag(4, WireType.LengthDelimited).string(message.entrypoints[i]);
         /* repeated bytes model_selectors = 5; */
         for (let i = 0; i < message.model_selectors.length; i++)
-            writer
-                .tag(5, WireType.LengthDelimited)
-                .bytes(message.model_selectors[i]);
+            writer.tag(5, WireType.LengthDelimited).bytes(message.model_selectors[i]);
         /* optional uint64 from_block = 6; */
         if (message.from_block !== undefined)
             writer.tag(6, WireType.Varint).uint64(message.from_block);
@@ -3859,11 +2541,7 @@ class TransactionFilter$Type extends MessageType<TransactionFilter> {
             writer.tag(7, WireType.Varint).uint64(message.to_block);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3875,93 +2553,48 @@ export const TransactionFilter = new TransactionFilter$Type();
 class TransactionQuery$Type extends MessageType<TransactionQuery> {
     constructor() {
         super("types.TransactionQuery", [
-            {
-                no: 1,
-                name: "filter",
-                kind: "message",
-                T: () => TransactionFilter,
-            },
-            { no: 2, name: "pagination", kind: "message", T: () => Pagination },
+            { no: 1, name: "filter", kind: "message", T: () => TransactionFilter },
+            { no: 2, name: "pagination", kind: "message", T: () => Pagination }
         ]);
     }
     create(value?: PartialMessage<TransactionQuery>): TransactionQuery {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
             reflectionMergePartial<TransactionQuery>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: TransactionQuery
-    ): TransactionQuery {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TransactionQuery): TransactionQuery {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.TransactionFilter filter */ 1:
-                    message.filter = TransactionFilter.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.filter
-                    );
+                    message.filter = TransactionFilter.internalBinaryRead(reader, reader.uint32(), options, message.filter);
                     break;
                 case /* types.Pagination pagination */ 2:
-                    message.pagination = Pagination.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.pagination
-                    );
+                    message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: TransactionQuery,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: TransactionQuery, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.TransactionFilter filter = 1; */
         if (message.filter)
-            TransactionFilter.internalBinaryWrite(
-                message.filter,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TransactionFilter.internalBinaryWrite(message.filter, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         /* types.Pagination pagination = 2; */
         if (message.pagination)
-            Pagination.internalBinaryWrite(
-                message.pagination,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }

--- a/packages/grpc/src/generated/world.client.ts
+++ b/packages/grpc/src/generated/world.client.ts
@@ -58,211 +58,133 @@ export interface IWorldClient {
      *
      * @generated from protobuf rpc: SubscribeIndexer
      */
-    subscribeIndexer(
-        input: SubscribeIndexerRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<SubscribeIndexerRequest, SubscribeIndexerResponse>;
+    subscribeIndexer(input: SubscribeIndexerRequest, options?: RpcOptions): ServerStreamingCall<SubscribeIndexerRequest, SubscribeIndexerResponse>;
     /**
      * Retrieves metadata about the World including all the registered components and systems.
      *
      * @generated from protobuf rpc: WorldMetadata
      */
-    worldMetadata(
-        input: WorldMetadataRequest,
-        options?: RpcOptions
-    ): UnaryCall<WorldMetadataRequest, WorldMetadataResponse>;
+    worldMetadata(input: WorldMetadataRequest, options?: RpcOptions): UnaryCall<WorldMetadataRequest, WorldMetadataResponse>;
     /**
      * Subscribe to entity updates.
      *
      * @generated from protobuf rpc: SubscribeEntities
      */
-    subscribeEntities(
-        input: SubscribeEntitiesRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<SubscribeEntitiesRequest, SubscribeEntityResponse>;
+    subscribeEntities(input: SubscribeEntitiesRequest, options?: RpcOptions): ServerStreamingCall<SubscribeEntitiesRequest, SubscribeEntityResponse>;
     /**
      * Update entity subscription
      *
      * @generated from protobuf rpc: UpdateEntitiesSubscription
      */
-    updateEntitiesSubscription(
-        input: UpdateEntitiesSubscriptionRequest,
-        options?: RpcOptions
-    ): UnaryCall<UpdateEntitiesSubscriptionRequest, Empty>;
+    updateEntitiesSubscription(input: UpdateEntitiesSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateEntitiesSubscriptionRequest, Empty>;
     /**
      * Retrieve entities
      *
      * @generated from protobuf rpc: RetrieveEntities
      */
-    retrieveEntities(
-        input: RetrieveEntitiesRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveEntitiesRequest, RetrieveEntitiesResponse>;
+    retrieveEntities(input: RetrieveEntitiesRequest, options?: RpcOptions): UnaryCall<RetrieveEntitiesRequest, RetrieveEntitiesResponse>;
     /**
      * Subscribe to entity updates.
      *
      * @generated from protobuf rpc: SubscribeEventMessages
      */
-    subscribeEventMessages(
-        input: SubscribeEventMessagesRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<
-        SubscribeEventMessagesRequest,
-        SubscribeEntityResponse
-    >;
+    subscribeEventMessages(input: SubscribeEventMessagesRequest, options?: RpcOptions): ServerStreamingCall<SubscribeEventMessagesRequest, SubscribeEntityResponse>;
     /**
      * Update entity subscription
      *
      * @generated from protobuf rpc: UpdateEventMessagesSubscription
      */
-    updateEventMessagesSubscription(
-        input: UpdateEventMessagesSubscriptionRequest,
-        options?: RpcOptions
-    ): UnaryCall<UpdateEventMessagesSubscriptionRequest, Empty>;
+    updateEventMessagesSubscription(input: UpdateEventMessagesSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateEventMessagesSubscriptionRequest, Empty>;
     /**
      * Subscribe to token balance updates.
      *
      * @generated from protobuf rpc: SubscribeTokenBalances
      */
-    subscribeTokenBalances(
-        input: SubscribeTokenBalancesRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<
-        SubscribeTokenBalancesRequest,
-        SubscribeTokenBalancesResponse
-    >;
+    subscribeTokenBalances(input: SubscribeTokenBalancesRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTokenBalancesRequest, SubscribeTokenBalancesResponse>;
     /**
      * Update token balance subscription
      *
      * @generated from protobuf rpc: UpdateTokenBalancesSubscription
      */
-    updateTokenBalancesSubscription(
-        input: UpdateTokenBalancesSubscriptionRequest,
-        options?: RpcOptions
-    ): UnaryCall<UpdateTokenBalancesSubscriptionRequest, Empty>;
+    updateTokenBalancesSubscription(input: UpdateTokenBalancesSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateTokenBalancesSubscriptionRequest, Empty>;
     /**
      * Subscribe to token updates.
      *
      * @generated from protobuf rpc: SubscribeTokens
      */
-    subscribeTokens(
-        input: SubscribeTokensRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<SubscribeTokensRequest, SubscribeTokensResponse>;
+    subscribeTokens(input: SubscribeTokensRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTokensRequest, SubscribeTokensResponse>;
     /**
      * Update token subscription
      *
      * @generated from protobuf rpc: UpdateTokensSubscription
      */
-    updateTokensSubscription(
-        input: UpdateTokenSubscriptionRequest,
-        options?: RpcOptions
-    ): UnaryCall<UpdateTokenSubscriptionRequest, Empty>;
+    updateTokensSubscription(input: UpdateTokenSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateTokenSubscriptionRequest, Empty>;
     /**
      * Retrieve entities
      *
      * @generated from protobuf rpc: RetrieveEventMessages
      */
-    retrieveEventMessages(
-        input: RetrieveEventMessagesRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveEventMessagesRequest, RetrieveEntitiesResponse>;
+    retrieveEventMessages(input: RetrieveEventMessagesRequest, options?: RpcOptions): UnaryCall<RetrieveEventMessagesRequest, RetrieveEntitiesResponse>;
     /**
      * Retrieve events
      *
      * @generated from protobuf rpc: RetrieveEvents
      */
-    retrieveEvents(
-        input: RetrieveEventsRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveEventsRequest, RetrieveEventsResponse>;
+    retrieveEvents(input: RetrieveEventsRequest, options?: RpcOptions): UnaryCall<RetrieveEventsRequest, RetrieveEventsResponse>;
     /**
      * Subscribe to events
      *
      * @generated from protobuf rpc: SubscribeEvents
      */
-    subscribeEvents(
-        input: SubscribeEventsRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<SubscribeEventsRequest, SubscribeEventsResponse>;
+    subscribeEvents(input: SubscribeEventsRequest, options?: RpcOptions): ServerStreamingCall<SubscribeEventsRequest, SubscribeEventsResponse>;
     /**
      * Retrieve tokens
      *
      * @generated from protobuf rpc: RetrieveTokens
      */
-    retrieveTokens(
-        input: RetrieveTokensRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveTokensRequest, RetrieveTokensResponse>;
+    retrieveTokens(input: RetrieveTokensRequest, options?: RpcOptions): UnaryCall<RetrieveTokensRequest, RetrieveTokensResponse>;
     /**
      * Retrieve token balances
      *
      * @generated from protobuf rpc: RetrieveTokenBalances
      */
-    retrieveTokenBalances(
-        input: RetrieveTokenBalancesRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse>;
+    retrieveTokenBalances(input: RetrieveTokenBalancesRequest, options?: RpcOptions): UnaryCall<RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse>;
     /**
      * Retrieve transactions
      *
      * @generated from protobuf rpc: RetrieveTransactions
      */
-    retrieveTransactions(
-        input: RetrieveTransactionsRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveTransactionsRequest, RetrieveTransactionsResponse>;
+    retrieveTransactions(input: RetrieveTransactionsRequest, options?: RpcOptions): UnaryCall<RetrieveTransactionsRequest, RetrieveTransactionsResponse>;
     /**
      * Subscribe to transactions
      *
      * @generated from protobuf rpc: SubscribeTransactions
      */
-    subscribeTransactions(
-        input: SubscribeTransactionsRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<
-        SubscribeTransactionsRequest,
-        SubscribeTransactionsResponse
-    >;
+    subscribeTransactions(input: SubscribeTransactionsRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTransactionsRequest, SubscribeTransactionsResponse>;
     /**
      * Retrieve controllers
      *
      * @generated from protobuf rpc: RetrieveControllers
      */
-    retrieveControllers(
-        input: RetrieveControllersRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveControllersRequest, RetrieveControllersResponse>;
+    retrieveControllers(input: RetrieveControllersRequest, options?: RpcOptions): UnaryCall<RetrieveControllersRequest, RetrieveControllersResponse>;
     /**
      * Retrieve tokens collections
      *
      * @generated from protobuf rpc: RetrieveTokenCollections
      */
-    retrieveTokenCollections(
-        input: RetrieveTokenCollectionsRequest,
-        options?: RpcOptions
-    ): UnaryCall<
-        RetrieveTokenCollectionsRequest,
-        RetrieveTokenCollectionsResponse
-    >;
+    retrieveTokenCollections(input: RetrieveTokenCollectionsRequest, options?: RpcOptions): UnaryCall<RetrieveTokenCollectionsRequest, RetrieveTokenCollectionsResponse>;
     /**
      * Publish a torii offchain message
      *
      * @generated from protobuf rpc: PublishMessage
      */
-    publishMessage(
-        input: PublishMessageRequest,
-        options?: RpcOptions
-    ): UnaryCall<PublishMessageRequest, PublishMessageResponse>;
+    publishMessage(input: PublishMessageRequest, options?: RpcOptions): UnaryCall<PublishMessageRequest, PublishMessageResponse>;
     /**
      * Publish a set of torii offchain messages
      *
      * @generated from protobuf rpc: PublishMessageBatch
      */
-    publishMessageBatch(
-        input: PublishMessageBatchRequest,
-        options?: RpcOptions
-    ): UnaryCall<PublishMessageBatchRequest, PublishMessageBatchResponse>;
+    publishMessageBatch(input: PublishMessageBatchRequest, options?: RpcOptions): UnaryCall<PublishMessageBatchRequest, PublishMessageBatchResponse>;
 }
 /**
  * The World service provides information about the world.
@@ -273,399 +195,204 @@ export class WorldClient implements IWorldClient, ServiceInfo {
     typeName = World.typeName;
     methods = World.methods;
     options = World.options;
-    constructor(private readonly _transport: RpcTransport) {}
+    constructor(private readonly _transport: RpcTransport) {
+    }
     /**
      * Subscribes to updates about the indexer. Like the head block number, tps, etc.
      *
      * @generated from protobuf rpc: SubscribeIndexer
      */
-    subscribeIndexer(
-        input: SubscribeIndexerRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<SubscribeIndexerRequest, SubscribeIndexerResponse> {
-        const method = this.methods[0],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            SubscribeIndexerRequest,
-            SubscribeIndexerResponse
-        >("serverStreaming", this._transport, method, opt, input);
+    subscribeIndexer(input: SubscribeIndexerRequest, options?: RpcOptions): ServerStreamingCall<SubscribeIndexerRequest, SubscribeIndexerResponse> {
+        const method = this.methods[0], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SubscribeIndexerRequest, SubscribeIndexerResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
      * Retrieves metadata about the World including all the registered components and systems.
      *
      * @generated from protobuf rpc: WorldMetadata
      */
-    worldMetadata(
-        input: WorldMetadataRequest,
-        options?: RpcOptions
-    ): UnaryCall<WorldMetadataRequest, WorldMetadataResponse> {
-        const method = this.methods[1],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<WorldMetadataRequest, WorldMetadataResponse>(
-            "unary",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    worldMetadata(input: WorldMetadataRequest, options?: RpcOptions): UnaryCall<WorldMetadataRequest, WorldMetadataResponse> {
+        const method = this.methods[1], opt = this._transport.mergeOptions(options);
+        return stackIntercept<WorldMetadataRequest, WorldMetadataResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Subscribe to entity updates.
      *
      * @generated from protobuf rpc: SubscribeEntities
      */
-    subscribeEntities(
-        input: SubscribeEntitiesRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<SubscribeEntitiesRequest, SubscribeEntityResponse> {
-        const method = this.methods[2],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            SubscribeEntitiesRequest,
-            SubscribeEntityResponse
-        >("serverStreaming", this._transport, method, opt, input);
+    subscribeEntities(input: SubscribeEntitiesRequest, options?: RpcOptions): ServerStreamingCall<SubscribeEntitiesRequest, SubscribeEntityResponse> {
+        const method = this.methods[2], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SubscribeEntitiesRequest, SubscribeEntityResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
      * Update entity subscription
      *
      * @generated from protobuf rpc: UpdateEntitiesSubscription
      */
-    updateEntitiesSubscription(
-        input: UpdateEntitiesSubscriptionRequest,
-        options?: RpcOptions
-    ): UnaryCall<UpdateEntitiesSubscriptionRequest, Empty> {
-        const method = this.methods[3],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<UpdateEntitiesSubscriptionRequest, Empty>(
-            "unary",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    updateEntitiesSubscription(input: UpdateEntitiesSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateEntitiesSubscriptionRequest, Empty> {
+        const method = this.methods[3], opt = this._transport.mergeOptions(options);
+        return stackIntercept<UpdateEntitiesSubscriptionRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
      * Retrieve entities
      *
      * @generated from protobuf rpc: RetrieveEntities
      */
-    retrieveEntities(
-        input: RetrieveEntitiesRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveEntitiesRequest, RetrieveEntitiesResponse> {
-        const method = this.methods[4],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            RetrieveEntitiesRequest,
-            RetrieveEntitiesResponse
-        >("unary", this._transport, method, opt, input);
+    retrieveEntities(input: RetrieveEntitiesRequest, options?: RpcOptions): UnaryCall<RetrieveEntitiesRequest, RetrieveEntitiesResponse> {
+        const method = this.methods[4], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveEntitiesRequest, RetrieveEntitiesResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Subscribe to entity updates.
      *
      * @generated from protobuf rpc: SubscribeEventMessages
      */
-    subscribeEventMessages(
-        input: SubscribeEventMessagesRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<
-        SubscribeEventMessagesRequest,
-        SubscribeEntityResponse
-    > {
-        const method = this.methods[5],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            SubscribeEventMessagesRequest,
-            SubscribeEntityResponse
-        >("serverStreaming", this._transport, method, opt, input);
+    subscribeEventMessages(input: SubscribeEventMessagesRequest, options?: RpcOptions): ServerStreamingCall<SubscribeEventMessagesRequest, SubscribeEntityResponse> {
+        const method = this.methods[5], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SubscribeEventMessagesRequest, SubscribeEntityResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
      * Update entity subscription
      *
      * @generated from protobuf rpc: UpdateEventMessagesSubscription
      */
-    updateEventMessagesSubscription(
-        input: UpdateEventMessagesSubscriptionRequest,
-        options?: RpcOptions
-    ): UnaryCall<UpdateEventMessagesSubscriptionRequest, Empty> {
-        const method = this.methods[6],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<UpdateEventMessagesSubscriptionRequest, Empty>(
-            "unary",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    updateEventMessagesSubscription(input: UpdateEventMessagesSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateEventMessagesSubscriptionRequest, Empty> {
+        const method = this.methods[6], opt = this._transport.mergeOptions(options);
+        return stackIntercept<UpdateEventMessagesSubscriptionRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
      * Subscribe to token balance updates.
      *
      * @generated from protobuf rpc: SubscribeTokenBalances
      */
-    subscribeTokenBalances(
-        input: SubscribeTokenBalancesRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<
-        SubscribeTokenBalancesRequest,
-        SubscribeTokenBalancesResponse
-    > {
-        const method = this.methods[7],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            SubscribeTokenBalancesRequest,
-            SubscribeTokenBalancesResponse
-        >("serverStreaming", this._transport, method, opt, input);
+    subscribeTokenBalances(input: SubscribeTokenBalancesRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTokenBalancesRequest, SubscribeTokenBalancesResponse> {
+        const method = this.methods[7], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SubscribeTokenBalancesRequest, SubscribeTokenBalancesResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
      * Update token balance subscription
      *
      * @generated from protobuf rpc: UpdateTokenBalancesSubscription
      */
-    updateTokenBalancesSubscription(
-        input: UpdateTokenBalancesSubscriptionRequest,
-        options?: RpcOptions
-    ): UnaryCall<UpdateTokenBalancesSubscriptionRequest, Empty> {
-        const method = this.methods[8],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<UpdateTokenBalancesSubscriptionRequest, Empty>(
-            "unary",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    updateTokenBalancesSubscription(input: UpdateTokenBalancesSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateTokenBalancesSubscriptionRequest, Empty> {
+        const method = this.methods[8], opt = this._transport.mergeOptions(options);
+        return stackIntercept<UpdateTokenBalancesSubscriptionRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
      * Subscribe to token updates.
      *
      * @generated from protobuf rpc: SubscribeTokens
      */
-    subscribeTokens(
-        input: SubscribeTokensRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<SubscribeTokensRequest, SubscribeTokensResponse> {
-        const method = this.methods[9],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<SubscribeTokensRequest, SubscribeTokensResponse>(
-            "serverStreaming",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    subscribeTokens(input: SubscribeTokensRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTokensRequest, SubscribeTokensResponse> {
+        const method = this.methods[9], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SubscribeTokensRequest, SubscribeTokensResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
      * Update token subscription
      *
      * @generated from protobuf rpc: UpdateTokensSubscription
      */
-    updateTokensSubscription(
-        input: UpdateTokenSubscriptionRequest,
-        options?: RpcOptions
-    ): UnaryCall<UpdateTokenSubscriptionRequest, Empty> {
-        const method = this.methods[10],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<UpdateTokenSubscriptionRequest, Empty>(
-            "unary",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    updateTokensSubscription(input: UpdateTokenSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateTokenSubscriptionRequest, Empty> {
+        const method = this.methods[10], opt = this._transport.mergeOptions(options);
+        return stackIntercept<UpdateTokenSubscriptionRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
      * Retrieve entities
      *
      * @generated from protobuf rpc: RetrieveEventMessages
      */
-    retrieveEventMessages(
-        input: RetrieveEventMessagesRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveEventMessagesRequest, RetrieveEntitiesResponse> {
-        const method = this.methods[11],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            RetrieveEventMessagesRequest,
-            RetrieveEntitiesResponse
-        >("unary", this._transport, method, opt, input);
+    retrieveEventMessages(input: RetrieveEventMessagesRequest, options?: RpcOptions): UnaryCall<RetrieveEventMessagesRequest, RetrieveEntitiesResponse> {
+        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveEventMessagesRequest, RetrieveEntitiesResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Retrieve events
      *
      * @generated from protobuf rpc: RetrieveEvents
      */
-    retrieveEvents(
-        input: RetrieveEventsRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveEventsRequest, RetrieveEventsResponse> {
-        const method = this.methods[12],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<RetrieveEventsRequest, RetrieveEventsResponse>(
-            "unary",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    retrieveEvents(input: RetrieveEventsRequest, options?: RpcOptions): UnaryCall<RetrieveEventsRequest, RetrieveEventsResponse> {
+        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveEventsRequest, RetrieveEventsResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Subscribe to events
      *
      * @generated from protobuf rpc: SubscribeEvents
      */
-    subscribeEvents(
-        input: SubscribeEventsRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<SubscribeEventsRequest, SubscribeEventsResponse> {
-        const method = this.methods[13],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<SubscribeEventsRequest, SubscribeEventsResponse>(
-            "serverStreaming",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    subscribeEvents(input: SubscribeEventsRequest, options?: RpcOptions): ServerStreamingCall<SubscribeEventsRequest, SubscribeEventsResponse> {
+        const method = this.methods[13], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SubscribeEventsRequest, SubscribeEventsResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
      * Retrieve tokens
      *
      * @generated from protobuf rpc: RetrieveTokens
      */
-    retrieveTokens(
-        input: RetrieveTokensRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveTokensRequest, RetrieveTokensResponse> {
-        const method = this.methods[14],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<RetrieveTokensRequest, RetrieveTokensResponse>(
-            "unary",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    retrieveTokens(input: RetrieveTokensRequest, options?: RpcOptions): UnaryCall<RetrieveTokensRequest, RetrieveTokensResponse> {
+        const method = this.methods[14], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveTokensRequest, RetrieveTokensResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Retrieve token balances
      *
      * @generated from protobuf rpc: RetrieveTokenBalances
      */
-    retrieveTokenBalances(
-        input: RetrieveTokenBalancesRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse> {
-        const method = this.methods[15],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            RetrieveTokenBalancesRequest,
-            RetrieveTokenBalancesResponse
-        >("unary", this._transport, method, opt, input);
+    retrieveTokenBalances(input: RetrieveTokenBalancesRequest, options?: RpcOptions): UnaryCall<RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse> {
+        const method = this.methods[15], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Retrieve transactions
      *
      * @generated from protobuf rpc: RetrieveTransactions
      */
-    retrieveTransactions(
-        input: RetrieveTransactionsRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveTransactionsRequest, RetrieveTransactionsResponse> {
-        const method = this.methods[16],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            RetrieveTransactionsRequest,
-            RetrieveTransactionsResponse
-        >("unary", this._transport, method, opt, input);
+    retrieveTransactions(input: RetrieveTransactionsRequest, options?: RpcOptions): UnaryCall<RetrieveTransactionsRequest, RetrieveTransactionsResponse> {
+        const method = this.methods[16], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveTransactionsRequest, RetrieveTransactionsResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Subscribe to transactions
      *
      * @generated from protobuf rpc: SubscribeTransactions
      */
-    subscribeTransactions(
-        input: SubscribeTransactionsRequest,
-        options?: RpcOptions
-    ): ServerStreamingCall<
-        SubscribeTransactionsRequest,
-        SubscribeTransactionsResponse
-    > {
-        const method = this.methods[17],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            SubscribeTransactionsRequest,
-            SubscribeTransactionsResponse
-        >("serverStreaming", this._transport, method, opt, input);
+    subscribeTransactions(input: SubscribeTransactionsRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTransactionsRequest, SubscribeTransactionsResponse> {
+        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SubscribeTransactionsRequest, SubscribeTransactionsResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
      * Retrieve controllers
      *
      * @generated from protobuf rpc: RetrieveControllers
      */
-    retrieveControllers(
-        input: RetrieveControllersRequest,
-        options?: RpcOptions
-    ): UnaryCall<RetrieveControllersRequest, RetrieveControllersResponse> {
-        const method = this.methods[18],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            RetrieveControllersRequest,
-            RetrieveControllersResponse
-        >("unary", this._transport, method, opt, input);
+    retrieveControllers(input: RetrieveControllersRequest, options?: RpcOptions): UnaryCall<RetrieveControllersRequest, RetrieveControllersResponse> {
+        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveControllersRequest, RetrieveControllersResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Retrieve tokens collections
      *
      * @generated from protobuf rpc: RetrieveTokenCollections
      */
-    retrieveTokenCollections(
-        input: RetrieveTokenCollectionsRequest,
-        options?: RpcOptions
-    ): UnaryCall<
-        RetrieveTokenCollectionsRequest,
-        RetrieveTokenCollectionsResponse
-    > {
-        const method = this.methods[19],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            RetrieveTokenCollectionsRequest,
-            RetrieveTokenCollectionsResponse
-        >("unary", this._transport, method, opt, input);
+    retrieveTokenCollections(input: RetrieveTokenCollectionsRequest, options?: RpcOptions): UnaryCall<RetrieveTokenCollectionsRequest, RetrieveTokenCollectionsResponse> {
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveTokenCollectionsRequest, RetrieveTokenCollectionsResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Publish a torii offchain message
      *
      * @generated from protobuf rpc: PublishMessage
      */
-    publishMessage(
-        input: PublishMessageRequest,
-        options?: RpcOptions
-    ): UnaryCall<PublishMessageRequest, PublishMessageResponse> {
-        const method = this.methods[20],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<PublishMessageRequest, PublishMessageResponse>(
-            "unary",
-            this._transport,
-            method,
-            opt,
-            input
-        );
+    publishMessage(input: PublishMessageRequest, options?: RpcOptions): UnaryCall<PublishMessageRequest, PublishMessageResponse> {
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        return stackIntercept<PublishMessageRequest, PublishMessageResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Publish a set of torii offchain messages
      *
      * @generated from protobuf rpc: PublishMessageBatch
      */
-    publishMessageBatch(
-        input: PublishMessageBatchRequest,
-        options?: RpcOptions
-    ): UnaryCall<PublishMessageBatchRequest, PublishMessageBatchResponse> {
-        const method = this.methods[21],
-            opt = this._transport.mergeOptions(options);
-        return stackIntercept<
-            PublishMessageBatchRequest,
-            PublishMessageBatchResponse
-        >("unary", this._transport, method, opt, input);
+    publishMessageBatch(input: PublishMessageBatchRequest, options?: RpcOptions): UnaryCall<PublishMessageBatchRequest, PublishMessageBatchResponse> {
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        return stackIntercept<PublishMessageBatchRequest, PublishMessageBatchResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/packages/grpc/src/generated/world.ts
+++ b/packages/grpc/src/generated/world.ts
@@ -350,7 +350,8 @@ export interface SubscribeIndexerResponse {
  *
  * @generated from protobuf message world.WorldMetadataRequest
  */
-export interface WorldMetadataRequest {}
+export interface WorldMetadataRequest {
+}
 /**
  * The metadata response contains addresses and class hashes for the world.
  *
@@ -540,256 +541,133 @@ export interface PublishMessageBatchResponse {
 class SubscribeTransactionsRequest$Type extends MessageType<SubscribeTransactionsRequest> {
     constructor() {
         super("world.SubscribeTransactionsRequest", [
-            {
-                no: 1,
-                name: "filter",
-                kind: "message",
-                T: () => TransactionFilter,
-            },
+            { no: 1, name: "filter", kind: "message", T: () => TransactionFilter }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeTransactionsRequest>
-    ): SubscribeTransactionsRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeTransactionsRequest>): SubscribeTransactionsRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<SubscribeTransactionsRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeTransactionsRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeTransactionsRequest
-    ): SubscribeTransactionsRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeTransactionsRequest): SubscribeTransactionsRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.TransactionFilter filter */ 1:
-                    message.filter = TransactionFilter.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.filter
-                    );
+                    message.filter = TransactionFilter.internalBinaryRead(reader, reader.uint32(), options, message.filter);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeTransactionsRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeTransactionsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.TransactionFilter filter = 1; */
         if (message.filter)
-            TransactionFilter.internalBinaryWrite(
-                message.filter,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TransactionFilter.internalBinaryWrite(message.filter, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.SubscribeTransactionsRequest
  */
-export const SubscribeTransactionsRequest =
-    new SubscribeTransactionsRequest$Type();
+export const SubscribeTransactionsRequest = new SubscribeTransactionsRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SubscribeTransactionsResponse$Type extends MessageType<SubscribeTransactionsResponse> {
     constructor() {
         super("world.SubscribeTransactionsResponse", [
-            {
-                no: 1,
-                name: "transaction",
-                kind: "message",
-                T: () => Transaction,
-            },
+            { no: 1, name: "transaction", kind: "message", T: () => Transaction }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeTransactionsResponse>
-    ): SubscribeTransactionsResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeTransactionsResponse>): SubscribeTransactionsResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<SubscribeTransactionsResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeTransactionsResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeTransactionsResponse
-    ): SubscribeTransactionsResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeTransactionsResponse): SubscribeTransactionsResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Transaction transaction */ 1:
-                    message.transaction = Transaction.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.transaction
-                    );
+                    message.transaction = Transaction.internalBinaryRead(reader, reader.uint32(), options, message.transaction);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeTransactionsResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeTransactionsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Transaction transaction = 1; */
         if (message.transaction)
-            Transaction.internalBinaryWrite(
-                message.transaction,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Transaction.internalBinaryWrite(message.transaction, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.SubscribeTransactionsResponse
  */
-export const SubscribeTransactionsResponse =
-    new SubscribeTransactionsResponse$Type();
+export const SubscribeTransactionsResponse = new SubscribeTransactionsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveControllersRequest$Type extends MessageType<RetrieveControllersRequest> {
     constructor() {
         super("world.RetrieveControllersRequest", [
-            { no: 1, name: "query", kind: "message", T: () => ControllerQuery },
+            { no: 1, name: "query", kind: "message", T: () => ControllerQuery }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveControllersRequest>
-    ): RetrieveControllersRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveControllersRequest>): RetrieveControllersRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<RetrieveControllersRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveControllersRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveControllersRequest
-    ): RetrieveControllersRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveControllersRequest): RetrieveControllersRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.ControllerQuery query */ 1:
-                    message.query = ControllerQuery.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.query
-                    );
+                    message.query = ControllerQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveControllersRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveControllersRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.ControllerQuery query = 1; */
         if (message.query)
-            ControllerQuery.internalBinaryWrite(
-                message.query,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            ControllerQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -801,44 +679,20 @@ export const RetrieveControllersRequest = new RetrieveControllersRequest$Type();
 class RetrieveControllersResponse$Type extends MessageType<RetrieveControllersResponse> {
     constructor() {
         super("world.RetrieveControllersResponse", [
-            {
-                no: 1,
-                name: "next_cursor",
-                kind: "scalar",
-                localName: "next_cursor",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "controllers",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Controller,
-            },
+            { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "controllers", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Controller }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveControllersResponse>
-    ): RetrieveControllersResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveControllersResponse>): RetrieveControllersResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.next_cursor = "";
         message.controllers = [];
         if (value !== undefined)
-            reflectionMergePartial<RetrieveControllersResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveControllersResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveControllersResponse
-    ): RetrieveControllersResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveControllersResponse): RetrieveControllersResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -846,125 +700,58 @@ class RetrieveControllersResponse$Type extends MessageType<RetrieveControllersRe
                     message.next_cursor = reader.string();
                     break;
                 case /* repeated types.Controller controllers */ 2:
-                    message.controllers.push(
-                        Controller.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.controllers.push(Controller.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveControllersResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveControllersResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string next_cursor = 1; */
         if (message.next_cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
         /* repeated types.Controller controllers = 2; */
         for (let i = 0; i < message.controllers.length; i++)
-            Controller.internalBinaryWrite(
-                message.controllers[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Controller.internalBinaryWrite(message.controllers[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.RetrieveControllersResponse
  */
-export const RetrieveControllersResponse =
-    new RetrieveControllersResponse$Type();
+export const RetrieveControllersResponse = new RetrieveControllersResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class UpdateTokenBalancesSubscriptionRequest$Type extends MessageType<UpdateTokenBalancesSubscriptionRequest> {
     constructor() {
         super("world.UpdateTokenBalancesSubscriptionRequest", [
-            {
-                no: 1,
-                name: "subscription_id",
-                kind: "scalar",
-                localName: "subscription_id",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 2,
-                name: "contract_addresses",
-                kind: "scalar",
-                localName: "contract_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "account_addresses",
-                kind: "scalar",
-                localName: "account_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 4,
-                name: "token_ids",
-                kind: "scalar",
-                localName: "token_ids",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "account_addresses", kind: "scalar", localName: "account_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<UpdateTokenBalancesSubscriptionRequest>
-    ): UpdateTokenBalancesSubscriptionRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<UpdateTokenBalancesSubscriptionRequest>): UpdateTokenBalancesSubscriptionRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.subscription_id = 0n;
         message.contract_addresses = [];
         message.account_addresses = [];
         message.token_ids = [];
         if (value !== undefined)
-            reflectionMergePartial<UpdateTokenBalancesSubscriptionRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<UpdateTokenBalancesSubscriptionRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: UpdateTokenBalancesSubscriptionRequest
-    ): UpdateTokenBalancesSubscriptionRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateTokenBalancesSubscriptionRequest): UpdateTokenBalancesSubscriptionRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -983,94 +770,54 @@ class UpdateTokenBalancesSubscriptionRequest$Type extends MessageType<UpdateToke
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: UpdateTokenBalancesSubscriptionRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: UpdateTokenBalancesSubscriptionRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* uint64 subscription_id = 1; */
         if (message.subscription_id !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.subscription_id);
         /* repeated bytes contract_addresses = 2; */
         for (let i = 0; i < message.contract_addresses.length; i++)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.contract_addresses[i]);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
         /* repeated bytes account_addresses = 3; */
         for (let i = 0; i < message.account_addresses.length; i++)
-            writer
-                .tag(3, WireType.LengthDelimited)
-                .bytes(message.account_addresses[i]);
+            writer.tag(3, WireType.LengthDelimited).bytes(message.account_addresses[i]);
         /* repeated bytes token_ids = 4; */
         for (let i = 0; i < message.token_ids.length; i++)
             writer.tag(4, WireType.LengthDelimited).bytes(message.token_ids[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.UpdateTokenBalancesSubscriptionRequest
  */
-export const UpdateTokenBalancesSubscriptionRequest =
-    new UpdateTokenBalancesSubscriptionRequest$Type();
+export const UpdateTokenBalancesSubscriptionRequest = new UpdateTokenBalancesSubscriptionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SubscribeTokenBalancesResponse$Type extends MessageType<SubscribeTokenBalancesResponse> {
     constructor() {
         super("world.SubscribeTokenBalancesResponse", [
-            {
-                no: 1,
-                name: "subscription_id",
-                kind: "scalar",
-                localName: "subscription_id",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            { no: 2, name: "balance", kind: "message", T: () => TokenBalance },
+            { no: 1, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "balance", kind: "message", T: () => TokenBalance }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeTokenBalancesResponse>
-    ): SubscribeTokenBalancesResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeTokenBalancesResponse>): SubscribeTokenBalancesResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.subscription_id = 0n;
         if (value !== undefined)
-            reflectionMergePartial<SubscribeTokenBalancesResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeTokenBalancesResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeTokenBalancesResponse
-    ): SubscribeTokenBalancesResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeTokenBalancesResponse): SubscribeTokenBalancesResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1078,134 +825,75 @@ class SubscribeTokenBalancesResponse$Type extends MessageType<SubscribeTokenBala
                     message.subscription_id = reader.uint64().toBigInt();
                     break;
                 case /* types.TokenBalance balance */ 2:
-                    message.balance = TokenBalance.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.balance
-                    );
+                    message.balance = TokenBalance.internalBinaryRead(reader, reader.uint32(), options, message.balance);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeTokenBalancesResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeTokenBalancesResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* uint64 subscription_id = 1; */
         if (message.subscription_id !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.subscription_id);
         /* types.TokenBalance balance = 2; */
         if (message.balance)
-            TokenBalance.internalBinaryWrite(
-                message.balance,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TokenBalance.internalBinaryWrite(message.balance, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.SubscribeTokenBalancesResponse
  */
-export const SubscribeTokenBalancesResponse =
-    new SubscribeTokenBalancesResponse$Type();
+export const SubscribeTokenBalancesResponse = new SubscribeTokenBalancesResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveTokensRequest$Type extends MessageType<RetrieveTokensRequest> {
     constructor() {
         super("world.RetrieveTokensRequest", [
-            { no: 1, name: "query", kind: "message", T: () => TokenQuery },
+            { no: 1, name: "query", kind: "message", T: () => TokenQuery }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveTokensRequest>
-    ): RetrieveTokensRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveTokensRequest>): RetrieveTokensRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
             reflectionMergePartial<RetrieveTokensRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveTokensRequest
-    ): RetrieveTokensRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTokensRequest): RetrieveTokensRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.TokenQuery query */ 1:
-                    message.query = TokenQuery.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.query
-                    );
+                    message.query = TokenQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveTokensRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveTokensRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.TokenQuery query = 1; */
         if (message.query)
-            TokenQuery.internalBinaryWrite(
-                message.query,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TokenQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1217,46 +905,20 @@ export const RetrieveTokensRequest = new RetrieveTokensRequest$Type();
 class SubscribeTokensRequest$Type extends MessageType<SubscribeTokensRequest> {
     constructor() {
         super("world.SubscribeTokensRequest", [
-            {
-                no: 1,
-                name: "contract_addresses",
-                kind: "scalar",
-                localName: "contract_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "token_ids",
-                kind: "scalar",
-                localName: "token_ids",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeTokensRequest>
-    ): SubscribeTokensRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeTokensRequest>): SubscribeTokensRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.contract_addresses = [];
         message.token_ids = [];
         if (value !== undefined)
-            reflectionMergePartial<SubscribeTokensRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeTokensRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeTokensRequest
-    ): SubscribeTokensRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeTokensRequest): SubscribeTokensRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1269,42 +931,24 @@ class SubscribeTokensRequest$Type extends MessageType<SubscribeTokensRequest> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeTokensRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeTokensRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes contract_addresses = 1; */
         for (let i = 0; i < message.contract_addresses.length; i++)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.contract_addresses[i]);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
         /* repeated bytes token_ids = 2; */
         for (let i = 0; i < message.token_ids.length; i++)
             writer.tag(2, WireType.LengthDelimited).bytes(message.token_ids[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1316,44 +960,20 @@ export const SubscribeTokensRequest = new SubscribeTokensRequest$Type();
 class RetrieveTokensResponse$Type extends MessageType<RetrieveTokensResponse> {
     constructor() {
         super("world.RetrieveTokensResponse", [
-            {
-                no: 1,
-                name: "next_cursor",
-                kind: "scalar",
-                localName: "next_cursor",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "tokens",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Token,
-            },
+            { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "tokens", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Token }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveTokensResponse>
-    ): RetrieveTokensResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveTokensResponse>): RetrieveTokensResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.next_cursor = "";
         message.tokens = [];
         if (value !== undefined)
-            reflectionMergePartial<RetrieveTokensResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveTokensResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveTokensResponse
-    ): RetrieveTokensResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTokensResponse): RetrieveTokensResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1361,55 +981,29 @@ class RetrieveTokensResponse$Type extends MessageType<RetrieveTokensResponse> {
                     message.next_cursor = reader.string();
                     break;
                 case /* repeated types.Token tokens */ 2:
-                    message.tokens.push(
-                        Token.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.tokens.push(Token.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveTokensResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveTokensResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string next_cursor = 1; */
         if (message.next_cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
         /* repeated types.Token tokens = 2; */
         for (let i = 0; i < message.tokens.length; i++)
-            Token.internalBinaryWrite(
-                message.tokens[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Token.internalBinaryWrite(message.tokens[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1421,38 +1015,19 @@ export const RetrieveTokensResponse = new RetrieveTokensResponse$Type();
 class SubscribeTokensResponse$Type extends MessageType<SubscribeTokensResponse> {
     constructor() {
         super("world.SubscribeTokensResponse", [
-            {
-                no: 1,
-                name: "subscription_id",
-                kind: "scalar",
-                localName: "subscription_id",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            { no: 2, name: "token", kind: "message", T: () => Token },
+            { no: 1, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "token", kind: "message", T: () => Token }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeTokensResponse>
-    ): SubscribeTokensResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeTokensResponse>): SubscribeTokensResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.subscription_id = 0n;
         if (value !== undefined)
-            reflectionMergePartial<SubscribeTokensResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeTokensResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeTokensResponse
-    ): SubscribeTokensResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeTokensResponse): SubscribeTokensResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1460,54 +1035,29 @@ class SubscribeTokensResponse$Type extends MessageType<SubscribeTokensResponse> 
                     message.subscription_id = reader.uint64().toBigInt();
                     break;
                 case /* types.Token token */ 2:
-                    message.token = Token.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.token
-                    );
+                    message.token = Token.internalBinaryRead(reader, reader.uint32(), options, message.token);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeTokensResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeTokensResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* uint64 subscription_id = 1; */
         if (message.subscription_id !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.subscription_id);
         /* types.Token token = 2; */
         if (message.token)
-            Token.internalBinaryWrite(
-                message.token,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Token.internalBinaryWrite(message.token, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -1519,55 +1069,22 @@ export const SubscribeTokensResponse = new SubscribeTokensResponse$Type();
 class UpdateTokenSubscriptionRequest$Type extends MessageType<UpdateTokenSubscriptionRequest> {
     constructor() {
         super("world.UpdateTokenSubscriptionRequest", [
-            {
-                no: 1,
-                name: "subscription_id",
-                kind: "scalar",
-                localName: "subscription_id",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 2,
-                name: "contract_addresses",
-                kind: "scalar",
-                localName: "contract_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "token_ids",
-                kind: "scalar",
-                localName: "token_ids",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<UpdateTokenSubscriptionRequest>
-    ): UpdateTokenSubscriptionRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<UpdateTokenSubscriptionRequest>): UpdateTokenSubscriptionRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.subscription_id = 0n;
         message.contract_addresses = [];
         message.token_ids = [];
         if (value !== undefined)
-            reflectionMergePartial<UpdateTokenSubscriptionRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<UpdateTokenSubscriptionRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: UpdateTokenSubscriptionRequest
-    ): UpdateTokenSubscriptionRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateTokenSubscriptionRequest): UpdateTokenSubscriptionRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1583,195 +1100,100 @@ class UpdateTokenSubscriptionRequest$Type extends MessageType<UpdateTokenSubscri
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: UpdateTokenSubscriptionRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: UpdateTokenSubscriptionRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* uint64 subscription_id = 1; */
         if (message.subscription_id !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.subscription_id);
         /* repeated bytes contract_addresses = 2; */
         for (let i = 0; i < message.contract_addresses.length; i++)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.contract_addresses[i]);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
         /* repeated bytes token_ids = 3; */
         for (let i = 0; i < message.token_ids.length; i++)
             writer.tag(3, WireType.LengthDelimited).bytes(message.token_ids[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.UpdateTokenSubscriptionRequest
  */
-export const UpdateTokenSubscriptionRequest =
-    new UpdateTokenSubscriptionRequest$Type();
+export const UpdateTokenSubscriptionRequest = new UpdateTokenSubscriptionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveTokenBalancesRequest$Type extends MessageType<RetrieveTokenBalancesRequest> {
     constructor() {
         super("world.RetrieveTokenBalancesRequest", [
-            {
-                no: 1,
-                name: "query",
-                kind: "message",
-                T: () => TokenBalanceQuery,
-            },
+            { no: 1, name: "query", kind: "message", T: () => TokenBalanceQuery }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveTokenBalancesRequest>
-    ): RetrieveTokenBalancesRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveTokenBalancesRequest>): RetrieveTokenBalancesRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<RetrieveTokenBalancesRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveTokenBalancesRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveTokenBalancesRequest
-    ): RetrieveTokenBalancesRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTokenBalancesRequest): RetrieveTokenBalancesRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.TokenBalanceQuery query */ 1:
-                    message.query = TokenBalanceQuery.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.query
-                    );
+                    message.query = TokenBalanceQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveTokenBalancesRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveTokenBalancesRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.TokenBalanceQuery query = 1; */
         if (message.query)
-            TokenBalanceQuery.internalBinaryWrite(
-                message.query,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TokenBalanceQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.RetrieveTokenBalancesRequest
  */
-export const RetrieveTokenBalancesRequest =
-    new RetrieveTokenBalancesRequest$Type();
+export const RetrieveTokenBalancesRequest = new RetrieveTokenBalancesRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SubscribeTokenBalancesRequest$Type extends MessageType<SubscribeTokenBalancesRequest> {
     constructor() {
         super("world.SubscribeTokenBalancesRequest", [
-            {
-                no: 1,
-                name: "account_addresses",
-                kind: "scalar",
-                localName: "account_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "contract_addresses",
-                kind: "scalar",
-                localName: "contract_addresses",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 3,
-                name: "token_ids",
-                kind: "scalar",
-                localName: "token_ids",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "account_addresses", kind: "scalar", localName: "account_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeTokenBalancesRequest>
-    ): SubscribeTokenBalancesRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeTokenBalancesRequest>): SubscribeTokenBalancesRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.account_addresses = [];
         message.contract_addresses = [];
         message.token_ids = [];
         if (value !== undefined)
-            reflectionMergePartial<SubscribeTokenBalancesRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeTokenBalancesRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeTokenBalancesRequest
-    ): SubscribeTokenBalancesRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeTokenBalancesRequest): SubscribeTokenBalancesRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1787,97 +1209,52 @@ class SubscribeTokenBalancesRequest$Type extends MessageType<SubscribeTokenBalan
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeTokenBalancesRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeTokenBalancesRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes account_addresses = 1; */
         for (let i = 0; i < message.account_addresses.length; i++)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.account_addresses[i]);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.account_addresses[i]);
         /* repeated bytes contract_addresses = 2; */
         for (let i = 0; i < message.contract_addresses.length; i++)
-            writer
-                .tag(2, WireType.LengthDelimited)
-                .bytes(message.contract_addresses[i]);
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
         /* repeated bytes token_ids = 3; */
         for (let i = 0; i < message.token_ids.length; i++)
             writer.tag(3, WireType.LengthDelimited).bytes(message.token_ids[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.SubscribeTokenBalancesRequest
  */
-export const SubscribeTokenBalancesRequest =
-    new SubscribeTokenBalancesRequest$Type();
+export const SubscribeTokenBalancesRequest = new SubscribeTokenBalancesRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveTokenBalancesResponse$Type extends MessageType<RetrieveTokenBalancesResponse> {
     constructor() {
         super("world.RetrieveTokenBalancesResponse", [
-            {
-                no: 1,
-                name: "next_cursor",
-                kind: "scalar",
-                localName: "next_cursor",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "balances",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => TokenBalance,
-            },
+            { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "balances", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => TokenBalance }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveTokenBalancesResponse>
-    ): RetrieveTokenBalancesResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveTokenBalancesResponse>): RetrieveTokenBalancesResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.next_cursor = "";
         message.balances = [];
         if (value !== undefined)
-            reflectionMergePartial<RetrieveTokenBalancesResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveTokenBalancesResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveTokenBalancesResponse
-    ): RetrieveTokenBalancesResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTokenBalancesResponse): RetrieveTokenBalancesResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -1885,194 +1262,100 @@ class RetrieveTokenBalancesResponse$Type extends MessageType<RetrieveTokenBalanc
                     message.next_cursor = reader.string();
                     break;
                 case /* repeated types.TokenBalance balances */ 2:
-                    message.balances.push(
-                        TokenBalance.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.balances.push(TokenBalance.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveTokenBalancesResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveTokenBalancesResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string next_cursor = 1; */
         if (message.next_cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
         /* repeated types.TokenBalance balances = 2; */
         for (let i = 0; i < message.balances.length; i++)
-            TokenBalance.internalBinaryWrite(
-                message.balances[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TokenBalance.internalBinaryWrite(message.balances[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.RetrieveTokenBalancesResponse
  */
-export const RetrieveTokenBalancesResponse =
-    new RetrieveTokenBalancesResponse$Type();
+export const RetrieveTokenBalancesResponse = new RetrieveTokenBalancesResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveTransactionsRequest$Type extends MessageType<RetrieveTransactionsRequest> {
     constructor() {
         super("world.RetrieveTransactionsRequest", [
-            {
-                no: 1,
-                name: "query",
-                kind: "message",
-                T: () => TransactionQuery,
-            },
+            { no: 1, name: "query", kind: "message", T: () => TransactionQuery }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveTransactionsRequest>
-    ): RetrieveTransactionsRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveTransactionsRequest>): RetrieveTransactionsRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<RetrieveTransactionsRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveTransactionsRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveTransactionsRequest
-    ): RetrieveTransactionsRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTransactionsRequest): RetrieveTransactionsRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.TransactionQuery query */ 1:
-                    message.query = TransactionQuery.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.query
-                    );
+                    message.query = TransactionQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveTransactionsRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveTransactionsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.TransactionQuery query = 1; */
         if (message.query)
-            TransactionQuery.internalBinaryWrite(
-                message.query,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TransactionQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.RetrieveTransactionsRequest
  */
-export const RetrieveTransactionsRequest =
-    new RetrieveTransactionsRequest$Type();
+export const RetrieveTransactionsRequest = new RetrieveTransactionsRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveTransactionsResponse$Type extends MessageType<RetrieveTransactionsResponse> {
     constructor() {
         super("world.RetrieveTransactionsResponse", [
-            {
-                no: 1,
-                name: "next_cursor",
-                kind: "scalar",
-                localName: "next_cursor",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "transactions",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Transaction,
-            },
+            { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "transactions", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Transaction }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveTransactionsResponse>
-    ): RetrieveTransactionsResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveTransactionsResponse>): RetrieveTransactionsResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.next_cursor = "";
         message.transactions = [];
         if (value !== undefined)
-            reflectionMergePartial<RetrieveTransactionsResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveTransactionsResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveTransactionsResponse
-    ): RetrieveTransactionsResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTransactionsResponse): RetrieveTransactionsResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2080,194 +1363,100 @@ class RetrieveTransactionsResponse$Type extends MessageType<RetrieveTransactions
                     message.next_cursor = reader.string();
                     break;
                 case /* repeated types.Transaction transactions */ 2:
-                    message.transactions.push(
-                        Transaction.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.transactions.push(Transaction.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveTransactionsResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveTransactionsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string next_cursor = 1; */
         if (message.next_cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
         /* repeated types.Transaction transactions = 2; */
         for (let i = 0; i < message.transactions.length; i++)
-            Transaction.internalBinaryWrite(
-                message.transactions[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Transaction.internalBinaryWrite(message.transactions[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.RetrieveTransactionsResponse
  */
-export const RetrieveTransactionsResponse =
-    new RetrieveTransactionsResponse$Type();
+export const RetrieveTransactionsResponse = new RetrieveTransactionsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveTokenCollectionsRequest$Type extends MessageType<RetrieveTokenCollectionsRequest> {
     constructor() {
         super("world.RetrieveTokenCollectionsRequest", [
-            {
-                no: 1,
-                name: "query",
-                kind: "message",
-                T: () => TokenBalanceQuery,
-            },
+            { no: 1, name: "query", kind: "message", T: () => TokenBalanceQuery }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveTokenCollectionsRequest>
-    ): RetrieveTokenCollectionsRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveTokenCollectionsRequest>): RetrieveTokenCollectionsRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<RetrieveTokenCollectionsRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveTokenCollectionsRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveTokenCollectionsRequest
-    ): RetrieveTokenCollectionsRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTokenCollectionsRequest): RetrieveTokenCollectionsRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.TokenBalanceQuery query */ 1:
-                    message.query = TokenBalanceQuery.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.query
-                    );
+                    message.query = TokenBalanceQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveTokenCollectionsRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveTokenCollectionsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.TokenBalanceQuery query = 1; */
         if (message.query)
-            TokenBalanceQuery.internalBinaryWrite(
-                message.query,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TokenBalanceQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.RetrieveTokenCollectionsRequest
  */
-export const RetrieveTokenCollectionsRequest =
-    new RetrieveTokenCollectionsRequest$Type();
+export const RetrieveTokenCollectionsRequest = new RetrieveTokenCollectionsRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveTokenCollectionsResponse$Type extends MessageType<RetrieveTokenCollectionsResponse> {
     constructor() {
         super("world.RetrieveTokenCollectionsResponse", [
-            {
-                no: 1,
-                name: "next_cursor",
-                kind: "scalar",
-                localName: "next_cursor",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "tokens",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => TokenCollection,
-            },
+            { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "tokens", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => TokenCollection }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveTokenCollectionsResponse>
-    ): RetrieveTokenCollectionsResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveTokenCollectionsResponse>): RetrieveTokenCollectionsResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.next_cursor = "";
         message.tokens = [];
         if (value !== undefined)
-            reflectionMergePartial<RetrieveTokenCollectionsResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveTokenCollectionsResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveTokenCollectionsResponse
-    ): RetrieveTokenCollectionsResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTokenCollectionsResponse): RetrieveTokenCollectionsResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2275,97 +1464,52 @@ class RetrieveTokenCollectionsResponse$Type extends MessageType<RetrieveTokenCol
                     message.next_cursor = reader.string();
                     break;
                 case /* repeated types.TokenCollection tokens */ 2:
-                    message.tokens.push(
-                        TokenCollection.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.tokens.push(TokenCollection.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveTokenCollectionsResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveTokenCollectionsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string next_cursor = 1; */
         if (message.next_cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
         /* repeated types.TokenCollection tokens = 2; */
         for (let i = 0; i < message.tokens.length; i++)
-            TokenCollection.internalBinaryWrite(
-                message.tokens[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            TokenCollection.internalBinaryWrite(message.tokens[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.RetrieveTokenCollectionsResponse
  */
-export const RetrieveTokenCollectionsResponse =
-    new RetrieveTokenCollectionsResponse$Type();
+export const RetrieveTokenCollectionsResponse = new RetrieveTokenCollectionsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SubscribeIndexerRequest$Type extends MessageType<SubscribeIndexerRequest> {
     constructor() {
         super("world.SubscribeIndexerRequest", [
-            {
-                no: 1,
-                name: "contract_address",
-                kind: "scalar",
-                localName: "contract_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeIndexerRequest>
-    ): SubscribeIndexerRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeIndexerRequest>): SubscribeIndexerRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.contract_address = new Uint8Array(0);
         if (value !== undefined)
-            reflectionMergePartial<SubscribeIndexerRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeIndexerRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeIndexerRequest
-    ): SubscribeIndexerRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeIndexerRequest): SubscribeIndexerRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2375,39 +1519,21 @@ class SubscribeIndexerRequest$Type extends MessageType<SubscribeIndexerRequest> 
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeIndexerRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeIndexerRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes contract_address = 1; */
         if (message.contract_address.length)
-            writer
-                .tag(1, WireType.LengthDelimited)
-                .bytes(message.contract_address);
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_address);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2419,61 +1545,24 @@ export const SubscribeIndexerRequest = new SubscribeIndexerRequest$Type();
 class SubscribeIndexerResponse$Type extends MessageType<SubscribeIndexerResponse> {
     constructor() {
         super("world.SubscribeIndexerResponse", [
-            {
-                no: 1,
-                name: "head",
-                kind: "scalar",
-                T: 3 /*ScalarType.INT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 2,
-                name: "tps",
-                kind: "scalar",
-                T: 3 /*ScalarType.INT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 3,
-                name: "last_block_timestamp",
-                kind: "scalar",
-                localName: "last_block_timestamp",
-                T: 3 /*ScalarType.INT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            {
-                no: 4,
-                name: "contract_address",
-                kind: "scalar",
-                localName: "contract_address",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "head", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "tps", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 3, name: "last_block_timestamp", kind: "scalar", localName: "last_block_timestamp", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 4, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeIndexerResponse>
-    ): SubscribeIndexerResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeIndexerResponse>): SubscribeIndexerResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.head = 0n;
         message.tps = 0n;
         message.last_block_timestamp = 0n;
         message.contract_address = new Uint8Array(0);
         if (value !== undefined)
-            reflectionMergePartial<SubscribeIndexerResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeIndexerResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeIndexerResponse
-    ): SubscribeIndexerResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeIndexerResponse): SubscribeIndexerResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2492,27 +1581,15 @@ class SubscribeIndexerResponse$Type extends MessageType<SubscribeIndexerResponse
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeIndexerResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeIndexerResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* int64 head = 1; */
         if (message.head !== 0n)
             writer.tag(1, WireType.Varint).int64(message.head);
@@ -2524,16 +1601,10 @@ class SubscribeIndexerResponse$Type extends MessageType<SubscribeIndexerResponse
             writer.tag(3, WireType.Varint).int64(message.last_block_timestamp);
         /* bytes contract_address = 4; */
         if (message.contract_address.length)
-            writer
-                .tag(4, WireType.LengthDelimited)
-                .bytes(message.contract_address);
+            writer.tag(4, WireType.LengthDelimited).bytes(message.contract_address);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2547,53 +1618,31 @@ class WorldMetadataRequest$Type extends MessageType<WorldMetadataRequest> {
         super("world.WorldMetadataRequest", []);
     }
     create(value?: PartialMessage<WorldMetadataRequest>): WorldMetadataRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
             reflectionMergePartial<WorldMetadataRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: WorldMetadataRequest
-    ): WorldMetadataRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: WorldMetadataRequest): WorldMetadataRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: WorldMetadataRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: WorldMetadataRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2605,74 +1654,41 @@ export const WorldMetadataRequest = new WorldMetadataRequest$Type();
 class WorldMetadataResponse$Type extends MessageType<WorldMetadataResponse> {
     constructor() {
         super("world.WorldMetadataResponse", [
-            { no: 1, name: "world", kind: "message", T: () => World$ },
+            { no: 1, name: "world", kind: "message", T: () => World$ }
         ]);
     }
-    create(
-        value?: PartialMessage<WorldMetadataResponse>
-    ): WorldMetadataResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<WorldMetadataResponse>): WorldMetadataResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
             reflectionMergePartial<WorldMetadataResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: WorldMetadataResponse
-    ): WorldMetadataResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: WorldMetadataResponse): WorldMetadataResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.World world */ 1:
-                    message.world = World$.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.world
-                    );
+                    message.world = World$.internalBinaryRead(reader, reader.uint32(), options, message.world);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: WorldMetadataResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: WorldMetadataResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.World world = 1; */
         if (message.world)
-            World$.internalBinaryWrite(
-                message.world,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            World$.internalBinaryWrite(message.world, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2684,78 +1700,41 @@ export const WorldMetadataResponse = new WorldMetadataResponse$Type();
 class SubscribeEntitiesRequest$Type extends MessageType<SubscribeEntitiesRequest> {
     constructor() {
         super("world.SubscribeEntitiesRequest", [
-            { no: 1, name: "clause", kind: "message", T: () => Clause },
+            { no: 1, name: "clause", kind: "message", T: () => Clause }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeEntitiesRequest>
-    ): SubscribeEntitiesRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeEntitiesRequest>): SubscribeEntitiesRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<SubscribeEntitiesRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeEntitiesRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeEntitiesRequest
-    ): SubscribeEntitiesRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeEntitiesRequest): SubscribeEntitiesRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Clause clause */ 1:
-                    message.clause = Clause.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.clause
-                    );
+                    message.clause = Clause.internalBinaryRead(reader, reader.uint32(), options, message.clause);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeEntitiesRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeEntitiesRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Clause clause = 1; */
         if (message.clause)
-            Clause.internalBinaryWrite(
-                message.clause,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Clause.internalBinaryWrite(message.clause, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -2767,122 +1746,65 @@ export const SubscribeEntitiesRequest = new SubscribeEntitiesRequest$Type();
 class SubscribeEventMessagesRequest$Type extends MessageType<SubscribeEventMessagesRequest> {
     constructor() {
         super("world.SubscribeEventMessagesRequest", [
-            { no: 1, name: "clause", kind: "message", T: () => Clause },
+            { no: 1, name: "clause", kind: "message", T: () => Clause }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeEventMessagesRequest>
-    ): SubscribeEventMessagesRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeEventMessagesRequest>): SubscribeEventMessagesRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<SubscribeEventMessagesRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeEventMessagesRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeEventMessagesRequest
-    ): SubscribeEventMessagesRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeEventMessagesRequest): SubscribeEventMessagesRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Clause clause */ 1:
-                    message.clause = Clause.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.clause
-                    );
+                    message.clause = Clause.internalBinaryRead(reader, reader.uint32(), options, message.clause);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeEventMessagesRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeEventMessagesRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Clause clause = 1; */
         if (message.clause)
-            Clause.internalBinaryWrite(
-                message.clause,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Clause.internalBinaryWrite(message.clause, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.SubscribeEventMessagesRequest
  */
-export const SubscribeEventMessagesRequest =
-    new SubscribeEventMessagesRequest$Type();
+export const SubscribeEventMessagesRequest = new SubscribeEventMessagesRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class UpdateEntitiesSubscriptionRequest$Type extends MessageType<UpdateEntitiesSubscriptionRequest> {
     constructor() {
         super("world.UpdateEntitiesSubscriptionRequest", [
-            {
-                no: 1,
-                name: "subscription_id",
-                kind: "scalar",
-                localName: "subscription_id",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            { no: 2, name: "clause", kind: "message", T: () => Clause },
+            { no: 1, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "clause", kind: "message", T: () => Clause }
         ]);
     }
-    create(
-        value?: PartialMessage<UpdateEntitiesSubscriptionRequest>
-    ): UpdateEntitiesSubscriptionRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<UpdateEntitiesSubscriptionRequest>): UpdateEntitiesSubscriptionRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.subscription_id = 0n;
         if (value !== undefined)
-            reflectionMergePartial<UpdateEntitiesSubscriptionRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<UpdateEntitiesSubscriptionRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: UpdateEntitiesSubscriptionRequest
-    ): UpdateEntitiesSubscriptionRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateEntitiesSubscriptionRequest): UpdateEntitiesSubscriptionRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2890,98 +1812,53 @@ class UpdateEntitiesSubscriptionRequest$Type extends MessageType<UpdateEntitiesS
                     message.subscription_id = reader.uint64().toBigInt();
                     break;
                 case /* types.Clause clause */ 2:
-                    message.clause = Clause.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.clause
-                    );
+                    message.clause = Clause.internalBinaryRead(reader, reader.uint32(), options, message.clause);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: UpdateEntitiesSubscriptionRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: UpdateEntitiesSubscriptionRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* uint64 subscription_id = 1; */
         if (message.subscription_id !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.subscription_id);
         /* types.Clause clause = 2; */
         if (message.clause)
-            Clause.internalBinaryWrite(
-                message.clause,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Clause.internalBinaryWrite(message.clause, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.UpdateEntitiesSubscriptionRequest
  */
-export const UpdateEntitiesSubscriptionRequest =
-    new UpdateEntitiesSubscriptionRequest$Type();
+export const UpdateEntitiesSubscriptionRequest = new UpdateEntitiesSubscriptionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class UpdateEventMessagesSubscriptionRequest$Type extends MessageType<UpdateEventMessagesSubscriptionRequest> {
     constructor() {
         super("world.UpdateEventMessagesSubscriptionRequest", [
-            {
-                no: 1,
-                name: "subscription_id",
-                kind: "scalar",
-                localName: "subscription_id",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
-            { no: 2, name: "clause", kind: "message", T: () => Clause },
+            { no: 1, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "clause", kind: "message", T: () => Clause }
         ]);
     }
-    create(
-        value?: PartialMessage<UpdateEventMessagesSubscriptionRequest>
-    ): UpdateEventMessagesSubscriptionRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<UpdateEventMessagesSubscriptionRequest>): UpdateEventMessagesSubscriptionRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.subscription_id = 0n;
         if (value !== undefined)
-            reflectionMergePartial<UpdateEventMessagesSubscriptionRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<UpdateEventMessagesSubscriptionRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: UpdateEventMessagesSubscriptionRequest
-    ): UpdateEventMessagesSubscriptionRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateEventMessagesSubscriptionRequest): UpdateEventMessagesSubscriptionRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -2989,108 +1866,58 @@ class UpdateEventMessagesSubscriptionRequest$Type extends MessageType<UpdateEven
                     message.subscription_id = reader.uint64().toBigInt();
                     break;
                 case /* types.Clause clause */ 2:
-                    message.clause = Clause.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.clause
-                    );
+                    message.clause = Clause.internalBinaryRead(reader, reader.uint32(), options, message.clause);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: UpdateEventMessagesSubscriptionRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: UpdateEventMessagesSubscriptionRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* uint64 subscription_id = 1; */
         if (message.subscription_id !== 0n)
             writer.tag(1, WireType.Varint).uint64(message.subscription_id);
         /* types.Clause clause = 2; */
         if (message.clause)
-            Clause.internalBinaryWrite(
-                message.clause,
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Clause.internalBinaryWrite(message.clause, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.UpdateEventMessagesSubscriptionRequest
  */
-export const UpdateEventMessagesSubscriptionRequest =
-    new UpdateEventMessagesSubscriptionRequest$Type();
+export const UpdateEventMessagesSubscriptionRequest = new UpdateEventMessagesSubscriptionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class SubscribeEntityResponse$Type extends MessageType<SubscribeEntityResponse> {
     constructor() {
         super("world.SubscribeEntityResponse", [
             { no: 1, name: "entity", kind: "message", T: () => Entity },
-            {
-                no: 2,
-                name: "subscription_id",
-                kind: "scalar",
-                localName: "subscription_id",
-                T: 4 /*ScalarType.UINT64*/,
-                L: 0 /*LongType.BIGINT*/,
-            },
+            { no: 2, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeEntityResponse>
-    ): SubscribeEntityResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeEntityResponse>): SubscribeEntityResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.subscription_id = 0n;
         if (value !== undefined)
-            reflectionMergePartial<SubscribeEntityResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeEntityResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeEntityResponse
-    ): SubscribeEntityResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeEntityResponse): SubscribeEntityResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Entity entity */ 1:
-                    message.entity = Entity.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.entity
-                    );
+                    message.entity = Entity.internalBinaryRead(reader, reader.uint32(), options, message.entity);
                     break;
                 case /* uint64 subscription_id */ 2:
                     message.subscription_id = reader.uint64().toBigInt();
@@ -3098,44 +1925,24 @@ class SubscribeEntityResponse$Type extends MessageType<SubscribeEntityResponse> 
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeEntityResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeEntityResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Entity entity = 1; */
         if (message.entity)
-            Entity.internalBinaryWrite(
-                message.entity,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Entity.internalBinaryWrite(message.entity, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         /* uint64 subscription_id = 2; */
         if (message.subscription_id !== 0n)
             writer.tag(2, WireType.Varint).uint64(message.subscription_id);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3147,78 +1954,41 @@ export const SubscribeEntityResponse = new SubscribeEntityResponse$Type();
 class RetrieveEntitiesRequest$Type extends MessageType<RetrieveEntitiesRequest> {
     constructor() {
         super("world.RetrieveEntitiesRequest", [
-            { no: 1, name: "query", kind: "message", T: () => Query },
+            { no: 1, name: "query", kind: "message", T: () => Query }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveEntitiesRequest>
-    ): RetrieveEntitiesRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveEntitiesRequest>): RetrieveEntitiesRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<RetrieveEntitiesRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveEntitiesRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveEntitiesRequest
-    ): RetrieveEntitiesRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveEntitiesRequest): RetrieveEntitiesRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Query query */ 1:
-                    message.query = Query.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.query
-                    );
+                    message.query = Query.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveEntitiesRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveEntitiesRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Query query = 1; */
         if (message.query)
-            Query.internalBinaryWrite(
-                message.query,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Query.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3230,128 +2000,66 @@ export const RetrieveEntitiesRequest = new RetrieveEntitiesRequest$Type();
 class RetrieveEventMessagesRequest$Type extends MessageType<RetrieveEventMessagesRequest> {
     constructor() {
         super("world.RetrieveEventMessagesRequest", [
-            { no: 1, name: "query", kind: "message", T: () => Query },
+            { no: 1, name: "query", kind: "message", T: () => Query }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveEventMessagesRequest>
-    ): RetrieveEventMessagesRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveEventMessagesRequest>): RetrieveEventMessagesRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<RetrieveEventMessagesRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveEventMessagesRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveEventMessagesRequest
-    ): RetrieveEventMessagesRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveEventMessagesRequest): RetrieveEventMessagesRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Query query */ 1:
-                    message.query = Query.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.query
-                    );
+                    message.query = Query.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveEventMessagesRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveEventMessagesRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Query query = 1; */
         if (message.query)
-            Query.internalBinaryWrite(
-                message.query,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Query.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.RetrieveEventMessagesRequest
  */
-export const RetrieveEventMessagesRequest =
-    new RetrieveEventMessagesRequest$Type();
+export const RetrieveEventMessagesRequest = new RetrieveEventMessagesRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class RetrieveEntitiesResponse$Type extends MessageType<RetrieveEntitiesResponse> {
     constructor() {
         super("world.RetrieveEntitiesResponse", [
-            {
-                no: 1,
-                name: "next_cursor",
-                kind: "scalar",
-                localName: "next_cursor",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "entities",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Entity,
-            },
+            { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "entities", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Entity }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveEntitiesResponse>
-    ): RetrieveEntitiesResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveEntitiesResponse>): RetrieveEntitiesResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.next_cursor = "";
         message.entities = [];
         if (value !== undefined)
-            reflectionMergePartial<RetrieveEntitiesResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveEntitiesResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveEntitiesResponse
-    ): RetrieveEntitiesResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveEntitiesResponse): RetrieveEntitiesResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3359,55 +2067,29 @@ class RetrieveEntitiesResponse$Type extends MessageType<RetrieveEntitiesResponse
                     message.next_cursor = reader.string();
                     break;
                 case /* repeated types.Entity entities */ 2:
-                    message.entities.push(
-                        Entity.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.entities.push(Entity.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveEntitiesResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveEntitiesResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string next_cursor = 1; */
         if (message.next_cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
         /* repeated types.Entity entities = 2; */
         for (let i = 0; i < message.entities.length; i++)
-            Entity.internalBinaryWrite(
-                message.entities[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Entity.internalBinaryWrite(message.entities[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3419,74 +2101,41 @@ export const RetrieveEntitiesResponse = new RetrieveEntitiesResponse$Type();
 class RetrieveEventsRequest$Type extends MessageType<RetrieveEventsRequest> {
     constructor() {
         super("world.RetrieveEventsRequest", [
-            { no: 1, name: "query", kind: "message", T: () => EventQuery },
+            { no: 1, name: "query", kind: "message", T: () => EventQuery }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveEventsRequest>
-    ): RetrieveEventsRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveEventsRequest>): RetrieveEventsRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
             reflectionMergePartial<RetrieveEventsRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveEventsRequest
-    ): RetrieveEventsRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveEventsRequest): RetrieveEventsRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.EventQuery query */ 1:
-                    message.query = EventQuery.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.query
-                    );
+                    message.query = EventQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveEventsRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveEventsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.EventQuery query = 1; */
         if (message.query)
-            EventQuery.internalBinaryWrite(
-                message.query,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            EventQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3498,44 +2147,20 @@ export const RetrieveEventsRequest = new RetrieveEventsRequest$Type();
 class RetrieveEventsResponse$Type extends MessageType<RetrieveEventsResponse> {
     constructor() {
         super("world.RetrieveEventsResponse", [
-            {
-                no: 1,
-                name: "next_cursor",
-                kind: "scalar",
-                localName: "next_cursor",
-                T: 9 /*ScalarType.STRING*/,
-            },
-            {
-                no: 2,
-                name: "events",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => Event,
-            },
+            { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "events", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Event }
         ]);
     }
-    create(
-        value?: PartialMessage<RetrieveEventsResponse>
-    ): RetrieveEventsResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<RetrieveEventsResponse>): RetrieveEventsResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.next_cursor = "";
         message.events = [];
         if (value !== undefined)
-            reflectionMergePartial<RetrieveEventsResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<RetrieveEventsResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: RetrieveEventsResponse
-    ): RetrieveEventsResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveEventsResponse): RetrieveEventsResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3543,55 +2168,29 @@ class RetrieveEventsResponse$Type extends MessageType<RetrieveEventsResponse> {
                     message.next_cursor = reader.string();
                     break;
                 case /* repeated types.Event events */ 2:
-                    message.events.push(
-                        Event.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.events.push(Event.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: RetrieveEventsResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: RetrieveEventsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* string next_cursor = 1; */
         if (message.next_cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
         /* repeated types.Event events = 2; */
         for (let i = 0; i < message.events.length; i++)
-            Event.internalBinaryWrite(
-                message.events[i],
-                writer.tag(2, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Event.internalBinaryWrite(message.events[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3603,86 +2202,42 @@ export const RetrieveEventsResponse = new RetrieveEventsResponse$Type();
 class SubscribeEventsRequest$Type extends MessageType<SubscribeEventsRequest> {
     constructor() {
         super("world.SubscribeEventsRequest", [
-            {
-                no: 1,
-                name: "keys",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => KeysClause,
-            },
+            { no: 1, name: "keys", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => KeysClause }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeEventsRequest>
-    ): SubscribeEventsRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeEventsRequest>): SubscribeEventsRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.keys = [];
         if (value !== undefined)
-            reflectionMergePartial<SubscribeEventsRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeEventsRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeEventsRequest
-    ): SubscribeEventsRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeEventsRequest): SubscribeEventsRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* repeated types.KeysClause keys */ 1:
-                    message.keys.push(
-                        KeysClause.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.keys.push(KeysClause.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeEventsRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeEventsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated types.KeysClause keys = 1; */
         for (let i = 0; i < message.keys.length; i++)
-            KeysClause.internalBinaryWrite(
-                message.keys[i],
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            KeysClause.internalBinaryWrite(message.keys[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3694,78 +2249,41 @@ export const SubscribeEventsRequest = new SubscribeEventsRequest$Type();
 class SubscribeEventsResponse$Type extends MessageType<SubscribeEventsResponse> {
     constructor() {
         super("world.SubscribeEventsResponse", [
-            { no: 1, name: "event", kind: "message", T: () => Event },
+            { no: 1, name: "event", kind: "message", T: () => Event }
         ]);
     }
-    create(
-        value?: PartialMessage<SubscribeEventsResponse>
-    ): SubscribeEventsResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<SubscribeEventsResponse>): SubscribeEventsResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<SubscribeEventsResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<SubscribeEventsResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: SubscribeEventsResponse
-    ): SubscribeEventsResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeEventsResponse): SubscribeEventsResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* types.Event event */ 1:
-                    message.event = Event.internalBinaryRead(
-                        reader,
-                        reader.uint32(),
-                        options,
-                        message.event
-                    );
+                    message.event = Event.internalBinaryRead(reader, reader.uint32(), options, message.event);
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: SubscribeEventsResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: SubscribeEventsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* types.Event event = 1; */
         if (message.event)
-            Event.internalBinaryWrite(
-                message.event,
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            Event.internalBinaryWrite(message.event, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3777,39 +2295,20 @@ export const SubscribeEventsResponse = new SubscribeEventsResponse$Type();
 class PublishMessageRequest$Type extends MessageType<PublishMessageRequest> {
     constructor() {
         super("world.PublishMessageRequest", [
-            {
-                no: 1,
-                name: "signature",
-                kind: "scalar",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: 12 /*ScalarType.BYTES*/,
-            },
-            {
-                no: 2,
-                name: "message",
-                kind: "scalar",
-                T: 9 /*ScalarType.STRING*/,
-            },
+            { no: 1, name: "signature", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "message", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<PublishMessageRequest>
-    ): PublishMessageRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<PublishMessageRequest>): PublishMessageRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.signature = [];
         message.message = "";
         if (value !== undefined)
             reflectionMergePartial<PublishMessageRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: PublishMessageRequest
-    ): PublishMessageRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: PublishMessageRequest): PublishMessageRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3822,27 +2321,15 @@ class PublishMessageRequest$Type extends MessageType<PublishMessageRequest> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: PublishMessageRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: PublishMessageRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated bytes signature = 1; */
         for (let i = 0; i < message.signature.length; i++)
             writer.tag(1, WireType.LengthDelimited).bytes(message.signature[i]);
@@ -3851,11 +2338,7 @@ class PublishMessageRequest$Type extends MessageType<PublishMessageRequest> {
             writer.tag(2, WireType.LengthDelimited).string(message.message);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3867,36 +2350,18 @@ export const PublishMessageRequest = new PublishMessageRequest$Type();
 class PublishMessageResponse$Type extends MessageType<PublishMessageResponse> {
     constructor() {
         super("world.PublishMessageResponse", [
-            {
-                no: 1,
-                name: "entity_id",
-                kind: "scalar",
-                localName: "entity_id",
-                T: 12 /*ScalarType.BYTES*/,
-            },
+            { no: 1, name: "entity_id", kind: "scalar", localName: "entity_id", T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
-    create(
-        value?: PartialMessage<PublishMessageResponse>
-    ): PublishMessageResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<PublishMessageResponse>): PublishMessageResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.entity_id = new Uint8Array(0);
         if (value !== undefined)
-            reflectionMergePartial<PublishMessageResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<PublishMessageResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: PublishMessageResponse
-    ): PublishMessageResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: PublishMessageResponse): PublishMessageResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
@@ -3906,37 +2371,21 @@ class PublishMessageResponse$Type extends MessageType<PublishMessageResponse> {
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: PublishMessageResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: PublishMessageResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* bytes entity_id = 1; */
         if (message.entity_id.length)
             writer.tag(1, WireType.LengthDelimited).bytes(message.entity_id);
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -3948,86 +2397,42 @@ export const PublishMessageResponse = new PublishMessageResponse$Type();
 class PublishMessageBatchRequest$Type extends MessageType<PublishMessageBatchRequest> {
     constructor() {
         super("world.PublishMessageBatchRequest", [
-            {
-                no: 1,
-                name: "messages",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => PublishMessageRequest,
-            },
+            { no: 1, name: "messages", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => PublishMessageRequest }
         ]);
     }
-    create(
-        value?: PartialMessage<PublishMessageBatchRequest>
-    ): PublishMessageBatchRequest {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<PublishMessageBatchRequest>): PublishMessageBatchRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.messages = [];
         if (value !== undefined)
-            reflectionMergePartial<PublishMessageBatchRequest>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<PublishMessageBatchRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: PublishMessageBatchRequest
-    ): PublishMessageBatchRequest {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: PublishMessageBatchRequest): PublishMessageBatchRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* repeated world.PublishMessageRequest messages */ 1:
-                    message.messages.push(
-                        PublishMessageRequest.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.messages.push(PublishMessageRequest.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: PublishMessageBatchRequest,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: PublishMessageBatchRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated world.PublishMessageRequest messages = 1; */
         for (let i = 0; i < message.messages.length; i++)
-            PublishMessageRequest.internalBinaryWrite(
-                message.messages[i],
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            PublishMessageRequest.internalBinaryWrite(message.messages[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
@@ -4039,235 +2444,73 @@ export const PublishMessageBatchRequest = new PublishMessageBatchRequest$Type();
 class PublishMessageBatchResponse$Type extends MessageType<PublishMessageBatchResponse> {
     constructor() {
         super("world.PublishMessageBatchResponse", [
-            {
-                no: 1,
-                name: "responses",
-                kind: "message",
-                repeat: 2 /*RepeatType.UNPACKED*/,
-                T: () => PublishMessageResponse,
-            },
+            { no: 1, name: "responses", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => PublishMessageResponse }
         ]);
     }
-    create(
-        value?: PartialMessage<PublishMessageBatchResponse>
-    ): PublishMessageBatchResponse {
-        const message = globalThis.Object.create(this.messagePrototype!);
+    create(value?: PartialMessage<PublishMessageBatchResponse>): PublishMessageBatchResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
         message.responses = [];
         if (value !== undefined)
-            reflectionMergePartial<PublishMessageBatchResponse>(
-                this,
-                message,
-                value
-            );
+            reflectionMergePartial<PublishMessageBatchResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(
-        reader: IBinaryReader,
-        length: number,
-        options: BinaryReadOptions,
-        target?: PublishMessageBatchResponse
-    ): PublishMessageBatchResponse {
-        let message = target ?? this.create(),
-            end = reader.pos + length;
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: PublishMessageBatchResponse): PublishMessageBatchResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
                 case /* repeated world.PublishMessageResponse responses */ 1:
-                    message.responses.push(
-                        PublishMessageResponse.internalBinaryRead(
-                            reader,
-                            reader.uint32(),
-                            options
-                        )
-                    );
+                    message.responses.push(PublishMessageResponse.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
-                        throw new globalThis.Error(
-                            `Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`
-                        );
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
                     let d = reader.skip(wireType);
                     if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(
-                            this.typeName,
-                            message,
-                            fieldNo,
-                            wireType,
-                            d
-                        );
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
             }
         }
         return message;
     }
-    internalBinaryWrite(
-        message: PublishMessageBatchResponse,
-        writer: IBinaryWriter,
-        options: BinaryWriteOptions
-    ): IBinaryWriter {
+    internalBinaryWrite(message: PublishMessageBatchResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* repeated world.PublishMessageResponse responses = 1; */
         for (let i = 0; i < message.responses.length; i++)
-            PublishMessageResponse.internalBinaryWrite(
-                message.responses[i],
-                writer.tag(1, WireType.LengthDelimited).fork(),
-                options
-            ).join();
+            PublishMessageResponse.internalBinaryWrite(message.responses[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(
-                this.typeName,
-                message,
-                writer
-            );
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
         return writer;
     }
 }
 /**
  * @generated MessageType for protobuf message world.PublishMessageBatchResponse
  */
-export const PublishMessageBatchResponse =
-    new PublishMessageBatchResponse$Type();
+export const PublishMessageBatchResponse = new PublishMessageBatchResponse$Type();
 /**
  * @generated ServiceType for protobuf service world.World
  */
 export const World = new ServiceType("world.World", [
-    {
-        name: "SubscribeIndexer",
-        serverStreaming: true,
-        options: {},
-        I: SubscribeIndexerRequest,
-        O: SubscribeIndexerResponse,
-    },
-    {
-        name: "WorldMetadata",
-        options: {},
-        I: WorldMetadataRequest,
-        O: WorldMetadataResponse,
-    },
-    {
-        name: "SubscribeEntities",
-        serverStreaming: true,
-        options: {},
-        I: SubscribeEntitiesRequest,
-        O: SubscribeEntityResponse,
-    },
-    {
-        name: "UpdateEntitiesSubscription",
-        options: {},
-        I: UpdateEntitiesSubscriptionRequest,
-        O: Empty,
-    },
-    {
-        name: "RetrieveEntities",
-        options: {},
-        I: RetrieveEntitiesRequest,
-        O: RetrieveEntitiesResponse,
-    },
-    {
-        name: "SubscribeEventMessages",
-        serverStreaming: true,
-        options: {},
-        I: SubscribeEventMessagesRequest,
-        O: SubscribeEntityResponse,
-    },
-    {
-        name: "UpdateEventMessagesSubscription",
-        options: {},
-        I: UpdateEventMessagesSubscriptionRequest,
-        O: Empty,
-    },
-    {
-        name: "SubscribeTokenBalances",
-        serverStreaming: true,
-        options: {},
-        I: SubscribeTokenBalancesRequest,
-        O: SubscribeTokenBalancesResponse,
-    },
-    {
-        name: "UpdateTokenBalancesSubscription",
-        options: {},
-        I: UpdateTokenBalancesSubscriptionRequest,
-        O: Empty,
-    },
-    {
-        name: "SubscribeTokens",
-        serverStreaming: true,
-        options: {},
-        I: SubscribeTokensRequest,
-        O: SubscribeTokensResponse,
-    },
-    {
-        name: "UpdateTokensSubscription",
-        options: {},
-        I: UpdateTokenSubscriptionRequest,
-        O: Empty,
-    },
-    {
-        name: "RetrieveEventMessages",
-        options: {},
-        I: RetrieveEventMessagesRequest,
-        O: RetrieveEntitiesResponse,
-    },
-    {
-        name: "RetrieveEvents",
-        options: {},
-        I: RetrieveEventsRequest,
-        O: RetrieveEventsResponse,
-    },
-    {
-        name: "SubscribeEvents",
-        serverStreaming: true,
-        options: {},
-        I: SubscribeEventsRequest,
-        O: SubscribeEventsResponse,
-    },
-    {
-        name: "RetrieveTokens",
-        options: {},
-        I: RetrieveTokensRequest,
-        O: RetrieveTokensResponse,
-    },
-    {
-        name: "RetrieveTokenBalances",
-        options: {},
-        I: RetrieveTokenBalancesRequest,
-        O: RetrieveTokenBalancesResponse,
-    },
-    {
-        name: "RetrieveTransactions",
-        options: {},
-        I: RetrieveTransactionsRequest,
-        O: RetrieveTransactionsResponse,
-    },
-    {
-        name: "SubscribeTransactions",
-        serverStreaming: true,
-        options: {},
-        I: SubscribeTransactionsRequest,
-        O: SubscribeTransactionsResponse,
-    },
-    {
-        name: "RetrieveControllers",
-        options: {},
-        I: RetrieveControllersRequest,
-        O: RetrieveControllersResponse,
-    },
-    {
-        name: "RetrieveTokenCollections",
-        options: {},
-        I: RetrieveTokenCollectionsRequest,
-        O: RetrieveTokenCollectionsResponse,
-    },
-    {
-        name: "PublishMessage",
-        options: {},
-        I: PublishMessageRequest,
-        O: PublishMessageResponse,
-    },
-    {
-        name: "PublishMessageBatch",
-        options: {},
-        I: PublishMessageBatchRequest,
-        O: PublishMessageBatchResponse,
-    },
+    { name: "SubscribeIndexer", serverStreaming: true, options: {}, I: SubscribeIndexerRequest, O: SubscribeIndexerResponse },
+    { name: "WorldMetadata", options: {}, I: WorldMetadataRequest, O: WorldMetadataResponse },
+    { name: "SubscribeEntities", serverStreaming: true, options: {}, I: SubscribeEntitiesRequest, O: SubscribeEntityResponse },
+    { name: "UpdateEntitiesSubscription", options: {}, I: UpdateEntitiesSubscriptionRequest, O: Empty },
+    { name: "RetrieveEntities", options: {}, I: RetrieveEntitiesRequest, O: RetrieveEntitiesResponse },
+    { name: "SubscribeEventMessages", serverStreaming: true, options: {}, I: SubscribeEventMessagesRequest, O: SubscribeEntityResponse },
+    { name: "UpdateEventMessagesSubscription", options: {}, I: UpdateEventMessagesSubscriptionRequest, O: Empty },
+    { name: "SubscribeTokenBalances", serverStreaming: true, options: {}, I: SubscribeTokenBalancesRequest, O: SubscribeTokenBalancesResponse },
+    { name: "UpdateTokenBalancesSubscription", options: {}, I: UpdateTokenBalancesSubscriptionRequest, O: Empty },
+    { name: "SubscribeTokens", serverStreaming: true, options: {}, I: SubscribeTokensRequest, O: SubscribeTokensResponse },
+    { name: "UpdateTokensSubscription", options: {}, I: UpdateTokenSubscriptionRequest, O: Empty },
+    { name: "RetrieveEventMessages", options: {}, I: RetrieveEventMessagesRequest, O: RetrieveEntitiesResponse },
+    { name: "RetrieveEvents", options: {}, I: RetrieveEventsRequest, O: RetrieveEventsResponse },
+    { name: "SubscribeEvents", serverStreaming: true, options: {}, I: SubscribeEventsRequest, O: SubscribeEventsResponse },
+    { name: "RetrieveTokens", options: {}, I: RetrieveTokensRequest, O: RetrieveTokensResponse },
+    { name: "RetrieveTokenBalances", options: {}, I: RetrieveTokenBalancesRequest, O: RetrieveTokenBalancesResponse },
+    { name: "RetrieveTransactions", options: {}, I: RetrieveTransactionsRequest, O: RetrieveTransactionsResponse },
+    { name: "SubscribeTransactions", serverStreaming: true, options: {}, I: SubscribeTransactionsRequest, O: SubscribeTransactionsResponse },
+    { name: "RetrieveControllers", options: {}, I: RetrieveControllersRequest, O: RetrieveControllersResponse },
+    { name: "RetrieveTokenCollections", options: {}, I: RetrieveTokenCollectionsRequest, O: RetrieveTokenCollectionsResponse },
+    { name: "PublishMessage", options: {}, I: PublishMessageRequest, O: PublishMessageResponse },
+    { name: "PublishMessageBatch", options: {}, I: PublishMessageBatchRequest, O: PublishMessageBatchResponse }
 ]);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced CLI commands to compile ABIs and generate TypeScript ABI types.
  * Added a comprehensive TypeScript type system for Cairo/StarkNet ABIs, enabling advanced type extraction and mapping.
  * Provided example usage and new documentation for ABI type extraction and usage in TypeScript projects.

* **Chores**
  * Updated build and script configurations for improved CLI and type checking support.
  * Removed unused linting scripts from the gRPC package.
  * Excluded example usage file from TypeScript compilation.

* **Documentation**
  * Added detailed README and example files to guide users on ABI type extraction and usage.

* **Refactor**
  * Updated gRPC client example to use a remote API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->