### PR TITLE
feat(grpc): bump torii version to 1.7.0-preview.6

### DIFF
--- a/.changeset/clever-melons-write.md
+++ b/.changeset/clever-melons-write.md
@@ -1,0 +1,7 @@
+---
+"@dojoengine/torii-wasm": patch
+"@dojoengine/internal": patch
+"@dojoengine/grpc": patch
+---
+
+feat(grpc): upgrade torii to preview.6

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,39 @@
+{
+  "mode": "pre",
+  "tag": "preview",
+  "initialVersions": {
+    "example-node-worker": "0.0.1",
+    "example-nodejs-bot": "0.0.1",
+    "example-predeployed-connector": "0.0.0",
+    "example-vanillajs-phaser-recs": "0.0.0",
+    "example-vite-experimental-sdk": "0.0.0",
+    "example-vite-grpc-playground": "0.0.0",
+    "example-vite-kitchen-sink": "0.1.0",
+    "example-vite-phaser-sdk": "1.5.4",
+    "example-vite-react-app-recs": "0.0.1",
+    "example-vite-react-phaser-recs": "0.1.0",
+    "example-vite-react-pwa-recs": "0.0.1",
+    "example-vite-react-sdk": "0.0.0",
+    "example-vite-react-sql": "1.0.0",
+    "example-vite-react-threejs-recs": "0.0.1",
+    "example-vite-svelte-recs": "0.0.0",
+    "example-vite-token-balance": "0.0.0",
+    "example-vue-app-recs": "0.0.0",
+    "@dojoengine/core": "1.7.0",
+    "@dojoengine/create-burner": "1.7.0",
+    "@dojoengine/create-dojo": "1.7.0",
+    "@dojoengine/grpc": "1.7.0",
+    "@dojoengine/internal": "1.6.7",
+    "@dojoengine/predeployed-connector": "1.7.0",
+    "@dojoengine/react": "1.7.0",
+    "@dojoengine/sdk": "1.7.0",
+    "@dojoengine/state": "1.7.0",
+    "@dojoengine/torii-client": "1.7.0",
+    "@dojoengine/torii-wasm": "1.7.0",
+    "@dojoengine/utils": "1.7.0",
+    "@dojoengine/utils-wasm": "1.7.0"
+  },
+  "changesets": [
+    "clever-melons-write"
+  ]
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "preview",
   "initialVersions": {
     "example-node-worker": "0.0.1",

--- a/packages/grpc/CHANGELOG.md
+++ b/packages/grpc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dojoengine/grpc
 
+## 1.7.1-preview.0
+
+### Patch Changes
+
+- 4060bc6: feat(grpc): upgrade torii to preview.6
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dojoengine/grpc",
-    "version": "1.7.0",
+    "version": "1.7.1-preview.0",
     "author": "Dojo Team",
     "license": "MIT",
     "description": "Dojo SDK: Build onchain and provable apps faster",

--- a/packages/grpc/proto/schema.proto
+++ b/packages/grpc/proto/schema.proto
@@ -42,6 +42,11 @@ message Array {
     repeated Ty children = 1;
 }
 
+message FixedSizeArray {
+    repeated Ty children = 1;
+    uint32 size = 2;
+}
+
 message Ty {
     oneof ty_type {
         Primitive primitive = 2;
@@ -50,6 +55,7 @@ message Ty {
         Array tuple = 5;
         Array array = 6;
         string bytearray = 7;
+        FixedSizeArray fixed_size_array = 8;
     }
 }
 

--- a/packages/grpc/proto/types.proto
+++ b/packages/grpc/proto/types.proto
@@ -6,7 +6,7 @@ import "schema.proto";
 message World {
     // The hex-encoded address of the world.
     string world_address = 1;
-    // A list of metadata for all registered components in the world. 
+    // A list of metadata for all registered components in the world.
     repeated Model models = 2;
 }
 
@@ -29,6 +29,8 @@ message Model {
     bytes schema = 8;
     // felt bytes of the contract address of the component
     bytes contract_address = 9;
+
+    bool use_legacy_store = 10;
 }
 
 message Entity {
@@ -36,6 +38,12 @@ message Entity {
     bytes hashed_keys = 1;
     // Models of the entity
     repeated Struct models = 2;
+    // Created at timestamp
+    uint64 created_at = 3;
+    // Updated at timestamp
+    uint64 updated_at = 4;
+    // Block timestamp when the entity was updated
+    uint64 executed_at = 5;
 }
 
 message Event {
@@ -122,6 +130,13 @@ enum ComparisonOperator {
     LTE = 5;
     IN = 6;
     NOT_IN = 7;
+    // Array-specific operators
+    CONTAINS = 8;           // Array contains value
+    CONTAINS_ALL = 9;       // Array contains all values
+    CONTAINS_ANY = 10;      // Array contains any of the values
+    ARRAY_LENGTH_EQ = 11;   // Array length equals
+    ARRAY_LENGTH_GT = 12;   // Array length greater than
+    ARRAY_LENGTH_LT = 13;   // Array length less than
 }
 
 message Token {
@@ -131,6 +146,7 @@ message Token {
     string symbol = 4;
     uint32 decimals = 5;
     bytes metadata = 6;
+    optional bytes total_supply = 7;
 }
 
 message TokenCollection {
@@ -272,4 +288,40 @@ message TransactionQuery {
     TransactionFilter filter = 1;
     // Pagination
     Pagination pagination = 2;
+}
+
+enum ContractType {
+    WORLD = 0;
+    ERC20 = 1;
+    ERC721 = 2;
+    ERC1155 = 3;
+    UDC = 4;
+    OTHER = 5;
+}
+
+message Contract {
+    // The contract address
+    bytes contract_address = 1;
+    // The type of contract
+    ContractType contract_type = 2;
+    // Current block height
+    optional uint64 head = 3;
+    // Transactions per second
+    optional uint64 tps = 4;
+    // Last block timestamp
+    optional uint64 last_block_timestamp = 5;
+    // Last pending block transaction
+    optional bytes last_pending_block_tx = 6;
+    // When the contract was last updated
+    uint64 updated_at = 7;
+    // When the contract was first tracked
+    uint64 created_at = 8;
+}
+
+// A request to retrieve contracts
+message ContractQuery {
+    // The list of contract addresses to retrieve
+    repeated bytes contract_addresses = 1;
+    // The list of contract types to filter by
+    repeated ContractType contract_types = 2;
 }

--- a/packages/grpc/proto/world.proto
+++ b/packages/grpc/proto/world.proto
@@ -7,8 +7,8 @@ import "google/protobuf/empty.proto";
 
 // The World service provides information about the world.
 service World {
-    // Subscribes to updates about the indexer. Like the head block number, tps, etc.
-    rpc SubscribeIndexer (SubscribeIndexerRequest) returns (stream SubscribeIndexerResponse);
+    // Subscribes to updates about contracts. Like the head block number, tps, etc.
+    rpc SubscribeContracts (SubscribeContractsRequest) returns (stream SubscribeContractsResponse);
 
     // Retrieves metadata about the World including all the registered components and systems.
     rpc WorldMetadata (WorldMetadataRequest) returns (WorldMetadataResponse);
@@ -64,6 +64,9 @@ service World {
     // Retrieve controllers
     rpc RetrieveControllers (RetrieveControllersRequest) returns (RetrieveControllersResponse);
 
+    // Retrieve contracts
+    rpc RetrieveContracts (RetrieveContractsRequest) returns (RetrieveContractsResponse);
+
     // Retrieve tokens collections
     rpc RetrieveTokenCollections (RetrieveTokenCollectionsRequest) returns (RetrieveTokenCollectionsResponse);
 
@@ -89,6 +92,14 @@ message RetrieveControllersRequest {
 message RetrieveControllersResponse {
     string next_cursor = 1;
     repeated types.Controller controllers = 2;
+}
+
+message RetrieveContractsRequest {
+    types.ContractQuery query = 1;
+}
+
+message RetrieveContractsResponse {
+    repeated types.Contract contracts = 1;
 }
 
 // A request to update a token balance subscription
@@ -191,17 +202,14 @@ message RetrieveTokenCollectionsResponse {
     repeated types.TokenCollection tokens = 2;
 }
 
-// A request to subscribe to indexer updates.
-message SubscribeIndexerRequest {
-    bytes contract_address = 1;
+// A request to subscribe to contract updates.
+message SubscribeContractsRequest {
+    types.ContractQuery query = 1;
 }
 
-// A response containing indexer updates.
-message SubscribeIndexerResponse {
-    int64 head = 1;
-    int64 tps = 2;
-    int64 last_block_timestamp = 3;
-    bytes contract_address = 4;
+// A response containing contract updates.
+message SubscribeContractsResponse {
+    types.Contract contract = 1;
 }
 
 // A request to retrieve metadata for a specific world ID.

--- a/packages/grpc/src/generated/schema.ts
+++ b/packages/grpc/src/generated/schema.ts
@@ -170,6 +170,19 @@ export interface Array$ {
     children: Ty[];
 }
 /**
+ * @generated from protobuf message types.FixedSizeArray
+ */
+export interface FixedSizeArray {
+    /**
+     * @generated from protobuf field: repeated types.Ty children = 1
+     */
+    children: Ty[];
+    /**
+     * @generated from protobuf field: uint32 size = 2
+     */
+    size: number;
+}
+/**
  * @generated from protobuf message types.Ty
  */
 export interface Ty {
@@ -212,6 +225,12 @@ export interface Ty {
          * @generated from protobuf field: string bytearray = 7
          */
         bytearray: string;
+    } | {
+        oneofKind: "fixed_size_array";
+        /**
+         * @generated from protobuf field: types.FixedSizeArray fixed_size_array = 8
+         */
+        fixed_size_array: FixedSizeArray;
     } | {
         oneofKind: undefined;
     };
@@ -653,6 +672,61 @@ class Array$$Type extends MessageType<Array$> {
  */
 export const Array$ = new Array$$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class FixedSizeArray$Type extends MessageType<FixedSizeArray> {
+    constructor() {
+        super("types.FixedSizeArray", [
+            { no: 1, name: "children", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Ty },
+            { no: 2, name: "size", kind: "scalar", T: 13 /*ScalarType.UINT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<FixedSizeArray>): FixedSizeArray {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.children = [];
+        message.size = 0;
+        if (value !== undefined)
+            reflectionMergePartial<FixedSizeArray>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: FixedSizeArray): FixedSizeArray {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated types.Ty children */ 1:
+                    message.children.push(Ty.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* uint32 size */ 2:
+                    message.size = reader.uint32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: FixedSizeArray, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated types.Ty children = 1; */
+        for (let i = 0; i < message.children.length; i++)
+            Ty.internalBinaryWrite(message.children[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* uint32 size = 2; */
+        if (message.size !== 0)
+            writer.tag(2, WireType.Varint).uint32(message.size);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message types.FixedSizeArray
+ */
+export const FixedSizeArray = new FixedSizeArray$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class Ty$Type extends MessageType<Ty> {
     constructor() {
         super("types.Ty", [
@@ -661,7 +735,8 @@ class Ty$Type extends MessageType<Ty> {
             { no: 4, name: "struct", kind: "message", oneof: "ty_type", T: () => Struct },
             { no: 5, name: "tuple", kind: "message", oneof: "ty_type", T: () => Array$ },
             { no: 6, name: "array", kind: "message", oneof: "ty_type", T: () => Array$ },
-            { no: 7, name: "bytearray", kind: "scalar", oneof: "ty_type", T: 9 /*ScalarType.STRING*/ }
+            { no: 7, name: "bytearray", kind: "scalar", oneof: "ty_type", T: 9 /*ScalarType.STRING*/ },
+            { no: 8, name: "fixed_size_array", kind: "message", localName: "fixed_size_array", oneof: "ty_type", T: () => FixedSizeArray }
         ]);
     }
     create(value?: PartialMessage<Ty>): Ty {
@@ -712,6 +787,12 @@ class Ty$Type extends MessageType<Ty> {
                         bytearray: reader.string()
                     };
                     break;
+                case /* types.FixedSizeArray fixed_size_array */ 8:
+                    message.ty_type = {
+                        oneofKind: "fixed_size_array",
+                        fixed_size_array: FixedSizeArray.internalBinaryRead(reader, reader.uint32(), options, (message.ty_type as any).fixed_size_array)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -742,6 +823,9 @@ class Ty$Type extends MessageType<Ty> {
         /* string bytearray = 7; */
         if (message.ty_type.oneofKind === "bytearray")
             writer.tag(7, WireType.LengthDelimited).string(message.ty_type.bytearray);
+        /* types.FixedSizeArray fixed_size_array = 8; */
+        if (message.ty_type.oneofKind === "fixed_size_array")
+            FixedSizeArray.internalBinaryWrite(message.ty_type.fixed_size_array, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/grpc/src/generated/types.ts
+++ b/packages/grpc/src/generated/types.ts
@@ -87,6 +87,10 @@ export interface Model {
      * @generated from protobuf field: bytes contract_address = 9
      */
     contract_address: Uint8Array;
+    /**
+     * @generated from protobuf field: bool use_legacy_store = 10
+     */
+    use_legacy_store: boolean;
 }
 /**
  * @generated from protobuf message types.Entity
@@ -104,6 +108,24 @@ export interface Entity {
      * @generated from protobuf field: repeated types.Struct models = 2
      */
     models: Struct[];
+    /**
+     * Created at timestamp
+     *
+     * @generated from protobuf field: uint64 created_at = 3
+     */
+    created_at: bigint;
+    /**
+     * Updated at timestamp
+     *
+     * @generated from protobuf field: uint64 updated_at = 4
+     */
+    updated_at: bigint;
+    /**
+     * Block timestamp when the entity was updated
+     *
+     * @generated from protobuf field: uint64 executed_at = 5
+     */
+    executed_at: bigint;
 }
 /**
  * @generated from protobuf message types.Event
@@ -327,6 +349,10 @@ export interface Token {
      * @generated from protobuf field: bytes metadata = 6
      */
     metadata: Uint8Array;
+    /**
+     * @generated from protobuf field: optional bytes total_supply = 7
+     */
+    total_supply?: Uint8Array;
 }
 /**
  * @generated from protobuf message types.TokenCollection
@@ -677,6 +703,78 @@ export interface TransactionQuery {
     pagination?: Pagination;
 }
 /**
+ * @generated from protobuf message types.Contract
+ */
+export interface Contract {
+    /**
+     * The contract address
+     *
+     * @generated from protobuf field: bytes contract_address = 1
+     */
+    contract_address: Uint8Array;
+    /**
+     * The type of contract
+     *
+     * @generated from protobuf field: types.ContractType contract_type = 2
+     */
+    contract_type: ContractType;
+    /**
+     * Current block height
+     *
+     * @generated from protobuf field: optional uint64 head = 3
+     */
+    head?: bigint;
+    /**
+     * Transactions per second
+     *
+     * @generated from protobuf field: optional uint64 tps = 4
+     */
+    tps?: bigint;
+    /**
+     * Last block timestamp
+     *
+     * @generated from protobuf field: optional uint64 last_block_timestamp = 5
+     */
+    last_block_timestamp?: bigint;
+    /**
+     * Last pending block transaction
+     *
+     * @generated from protobuf field: optional bytes last_pending_block_tx = 6
+     */
+    last_pending_block_tx?: Uint8Array;
+    /**
+     * When the contract was last updated
+     *
+     * @generated from protobuf field: uint64 updated_at = 7
+     */
+    updated_at: bigint;
+    /**
+     * When the contract was first tracked
+     *
+     * @generated from protobuf field: uint64 created_at = 8
+     */
+    created_at: bigint;
+}
+/**
+ * A request to retrieve contracts
+ *
+ * @generated from protobuf message types.ContractQuery
+ */
+export interface ContractQuery {
+    /**
+     * The list of contract addresses to retrieve
+     *
+     * @generated from protobuf field: repeated bytes contract_addresses = 1
+     */
+    contract_addresses: Uint8Array[];
+    /**
+     * The list of contract types to filter by
+     *
+     * @generated from protobuf field: repeated types.ContractType contract_types = 2
+     */
+    contract_types: ContractType[];
+}
+/**
  * @generated from protobuf enum types.PatternMatching
  */
 export enum PatternMatching {
@@ -737,7 +835,45 @@ export enum ComparisonOperator {
     /**
      * @generated from protobuf enum value: NOT_IN = 7;
      */
-    NOT_IN = 7
+    NOT_IN = 7,
+    /**
+     * Array-specific operators
+     *
+     * Array contains value
+     *
+     * @generated from protobuf enum value: CONTAINS = 8;
+     */
+    CONTAINS = 8,
+    /**
+     * Array contains all values
+     *
+     * @generated from protobuf enum value: CONTAINS_ALL = 9;
+     */
+    CONTAINS_ALL = 9,
+    /**
+     * Array contains any of the values
+     *
+     * @generated from protobuf enum value: CONTAINS_ANY = 10;
+     */
+    CONTAINS_ANY = 10,
+    /**
+     * Array length equals
+     *
+     * @generated from protobuf enum value: ARRAY_LENGTH_EQ = 11;
+     */
+    ARRAY_LENGTH_EQ = 11,
+    /**
+     * Array length greater than
+     *
+     * @generated from protobuf enum value: ARRAY_LENGTH_GT = 12;
+     */
+    ARRAY_LENGTH_GT = 12,
+    /**
+     * Array length less than
+     *
+     * @generated from protobuf enum value: ARRAY_LENGTH_LT = 13;
+     */
+    ARRAY_LENGTH_LT = 13
 }
 /**
  * @generated from protobuf enum types.OrderDirection
@@ -777,6 +913,35 @@ export enum CallType {
      * @generated from protobuf enum value: EXECUTE_FROM_OUTSIDE = 1;
      */
     EXECUTE_FROM_OUTSIDE = 1
+}
+/**
+ * @generated from protobuf enum types.ContractType
+ */
+export enum ContractType {
+    /**
+     * @generated from protobuf enum value: WORLD = 0;
+     */
+    WORLD = 0,
+    /**
+     * @generated from protobuf enum value: ERC20 = 1;
+     */
+    ERC20 = 1,
+    /**
+     * @generated from protobuf enum value: ERC721 = 2;
+     */
+    ERC721 = 2,
+    /**
+     * @generated from protobuf enum value: ERC1155 = 3;
+     */
+    ERC1155 = 3,
+    /**
+     * @generated from protobuf enum value: UDC = 4;
+     */
+    UDC = 4,
+    /**
+     * @generated from protobuf enum value: OTHER = 5;
+     */
+    OTHER = 5
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class World$Type extends MessageType<World> {
@@ -845,7 +1010,8 @@ class Model$Type extends MessageType<Model> {
             { no: 6, name: "class_hash", kind: "scalar", localName: "class_hash", T: 12 /*ScalarType.BYTES*/ },
             { no: 7, name: "layout", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 8, name: "schema", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
-            { no: 9, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ }
+            { no: 9, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 10, name: "use_legacy_store", kind: "scalar", localName: "use_legacy_store", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
     create(value?: PartialMessage<Model>): Model {
@@ -859,6 +1025,7 @@ class Model$Type extends MessageType<Model> {
         message.layout = new Uint8Array(0);
         message.schema = new Uint8Array(0);
         message.contract_address = new Uint8Array(0);
+        message.use_legacy_store = false;
         if (value !== undefined)
             reflectionMergePartial<Model>(this, message, value);
         return message;
@@ -894,6 +1061,9 @@ class Model$Type extends MessageType<Model> {
                     break;
                 case /* bytes contract_address */ 9:
                     message.contract_address = reader.bytes();
+                    break;
+                case /* bool use_legacy_store */ 10:
+                    message.use_legacy_store = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -934,6 +1104,9 @@ class Model$Type extends MessageType<Model> {
         /* bytes contract_address = 9; */
         if (message.contract_address.length)
             writer.tag(9, WireType.LengthDelimited).bytes(message.contract_address);
+        /* bool use_legacy_store = 10; */
+        if (message.use_legacy_store !== false)
+            writer.tag(10, WireType.Varint).bool(message.use_legacy_store);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -949,13 +1122,19 @@ class Entity$Type extends MessageType<Entity> {
     constructor() {
         super("types.Entity", [
             { no: 1, name: "hashed_keys", kind: "scalar", localName: "hashed_keys", T: 12 /*ScalarType.BYTES*/ },
-            { no: 2, name: "models", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Struct }
+            { no: 2, name: "models", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Struct },
+            { no: 3, name: "created_at", kind: "scalar", localName: "created_at", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 4, name: "updated_at", kind: "scalar", localName: "updated_at", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 5, name: "executed_at", kind: "scalar", localName: "executed_at", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
         ]);
     }
     create(value?: PartialMessage<Entity>): Entity {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.hashed_keys = new Uint8Array(0);
         message.models = [];
+        message.created_at = 0n;
+        message.updated_at = 0n;
+        message.executed_at = 0n;
         if (value !== undefined)
             reflectionMergePartial<Entity>(this, message, value);
         return message;
@@ -970,6 +1149,15 @@ class Entity$Type extends MessageType<Entity> {
                     break;
                 case /* repeated types.Struct models */ 2:
                     message.models.push(Struct.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* uint64 created_at */ 3:
+                    message.created_at = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 updated_at */ 4:
+                    message.updated_at = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 executed_at */ 5:
+                    message.executed_at = reader.uint64().toBigInt();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -989,6 +1177,15 @@ class Entity$Type extends MessageType<Entity> {
         /* repeated types.Struct models = 2; */
         for (let i = 0; i < message.models.length; i++)
             Struct.internalBinaryWrite(message.models[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* uint64 created_at = 3; */
+        if (message.created_at !== 0n)
+            writer.tag(3, WireType.Varint).uint64(message.created_at);
+        /* uint64 updated_at = 4; */
+        if (message.updated_at !== 0n)
+            writer.tag(4, WireType.Varint).uint64(message.updated_at);
+        /* uint64 executed_at = 5; */
+        if (message.executed_at !== 0n)
+            writer.tag(5, WireType.Varint).uint64(message.executed_at);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1633,7 +1830,8 @@ class Token$Type extends MessageType<Token> {
             { no: 3, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "symbol", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 5, name: "decimals", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 6, name: "metadata", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
+            { no: 6, name: "metadata", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 7, name: "total_supply", kind: "scalar", localName: "total_supply", opt: true, T: 12 /*ScalarType.BYTES*/ }
         ]);
     }
     create(value?: PartialMessage<Token>): Token {
@@ -1670,6 +1868,9 @@ class Token$Type extends MessageType<Token> {
                 case /* bytes metadata */ 6:
                     message.metadata = reader.bytes();
                     break;
+                case /* optional bytes total_supply */ 7:
+                    message.total_supply = reader.bytes();
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -1700,6 +1901,9 @@ class Token$Type extends MessageType<Token> {
         /* bytes metadata = 6; */
         if (message.metadata.length)
             writer.tag(6, WireType.LengthDelimited).bytes(message.metadata);
+        /* optional bytes total_supply = 7; */
+        if (message.total_supply !== undefined)
+            writer.tag(7, WireType.LengthDelimited).bytes(message.total_supply);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2602,3 +2806,165 @@ class TransactionQuery$Type extends MessageType<TransactionQuery> {
  * @generated MessageType for protobuf message types.TransactionQuery
  */
 export const TransactionQuery = new TransactionQuery$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class Contract$Type extends MessageType<Contract> {
+    constructor() {
+        super("types.Contract", [
+            { no: 1, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contract_type", kind: "enum", localName: "contract_type", T: () => ["types.ContractType", ContractType] },
+            { no: 3, name: "head", kind: "scalar", opt: true, T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 4, name: "tps", kind: "scalar", opt: true, T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 5, name: "last_block_timestamp", kind: "scalar", localName: "last_block_timestamp", opt: true, T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 6, name: "last_pending_block_tx", kind: "scalar", localName: "last_pending_block_tx", opt: true, T: 12 /*ScalarType.BYTES*/ },
+            { no: 7, name: "updated_at", kind: "scalar", localName: "updated_at", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 8, name: "created_at", kind: "scalar", localName: "created_at", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ }
+        ]);
+    }
+    create(value?: PartialMessage<Contract>): Contract {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.contract_address = new Uint8Array(0);
+        message.contract_type = 0;
+        message.updated_at = 0n;
+        message.created_at = 0n;
+        if (value !== undefined)
+            reflectionMergePartial<Contract>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: Contract): Contract {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* bytes contract_address */ 1:
+                    message.contract_address = reader.bytes();
+                    break;
+                case /* types.ContractType contract_type */ 2:
+                    message.contract_type = reader.int32();
+                    break;
+                case /* optional uint64 head */ 3:
+                    message.head = reader.uint64().toBigInt();
+                    break;
+                case /* optional uint64 tps */ 4:
+                    message.tps = reader.uint64().toBigInt();
+                    break;
+                case /* optional uint64 last_block_timestamp */ 5:
+                    message.last_block_timestamp = reader.uint64().toBigInt();
+                    break;
+                case /* optional bytes last_pending_block_tx */ 6:
+                    message.last_pending_block_tx = reader.bytes();
+                    break;
+                case /* uint64 updated_at */ 7:
+                    message.updated_at = reader.uint64().toBigInt();
+                    break;
+                case /* uint64 created_at */ 8:
+                    message.created_at = reader.uint64().toBigInt();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: Contract, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* bytes contract_address = 1; */
+        if (message.contract_address.length)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_address);
+        /* types.ContractType contract_type = 2; */
+        if (message.contract_type !== 0)
+            writer.tag(2, WireType.Varint).int32(message.contract_type);
+        /* optional uint64 head = 3; */
+        if (message.head !== undefined)
+            writer.tag(3, WireType.Varint).uint64(message.head);
+        /* optional uint64 tps = 4; */
+        if (message.tps !== undefined)
+            writer.tag(4, WireType.Varint).uint64(message.tps);
+        /* optional uint64 last_block_timestamp = 5; */
+        if (message.last_block_timestamp !== undefined)
+            writer.tag(5, WireType.Varint).uint64(message.last_block_timestamp);
+        /* optional bytes last_pending_block_tx = 6; */
+        if (message.last_pending_block_tx !== undefined)
+            writer.tag(6, WireType.LengthDelimited).bytes(message.last_pending_block_tx);
+        /* uint64 updated_at = 7; */
+        if (message.updated_at !== 0n)
+            writer.tag(7, WireType.Varint).uint64(message.updated_at);
+        /* uint64 created_at = 8; */
+        if (message.created_at !== 0n)
+            writer.tag(8, WireType.Varint).uint64(message.created_at);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message types.Contract
+ */
+export const Contract = new Contract$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ContractQuery$Type extends MessageType<ContractQuery> {
+    constructor() {
+        super("types.ContractQuery", [
+            { no: 1, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contract_types", kind: "enum", localName: "contract_types", repeat: 1 /*RepeatType.PACKED*/, T: () => ["types.ContractType", ContractType] }
+        ]);
+    }
+    create(value?: PartialMessage<ContractQuery>): ContractQuery {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.contract_addresses = [];
+        message.contract_types = [];
+        if (value !== undefined)
+            reflectionMergePartial<ContractQuery>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ContractQuery): ContractQuery {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated bytes contract_addresses */ 1:
+                    message.contract_addresses.push(reader.bytes());
+                    break;
+                case /* repeated types.ContractType contract_types */ 2:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.contract_types.push(reader.int32());
+                    else
+                        message.contract_types.push(reader.int32());
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ContractQuery, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated bytes contract_addresses = 1; */
+        for (let i = 0; i < message.contract_addresses.length; i++)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
+        /* repeated types.ContractType contract_types = 2; */
+        if (message.contract_types.length) {
+            writer.tag(2, WireType.LengthDelimited).fork();
+            for (let i = 0; i < message.contract_types.length; i++)
+                writer.int32(message.contract_types[i]);
+            writer.join();
+        }
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message types.ContractQuery
+ */
+export const ContractQuery = new ContractQuery$Type();

--- a/packages/grpc/src/generated/world.client.ts
+++ b/packages/grpc/src/generated/world.client.ts
@@ -10,6 +10,8 @@ import type { PublishMessageResponse } from "./world";
 import type { PublishMessageRequest } from "./world";
 import type { RetrieveTokenCollectionsResponse } from "./world";
 import type { RetrieveTokenCollectionsRequest } from "./world";
+import type { RetrieveContractsResponse } from "./world";
+import type { RetrieveContractsRequest } from "./world";
 import type { RetrieveControllersResponse } from "./world";
 import type { RetrieveControllersRequest } from "./world";
 import type { SubscribeTransactionsResponse } from "./world";
@@ -43,8 +45,8 @@ import type { WorldMetadataResponse } from "./world";
 import type { WorldMetadataRequest } from "./world";
 import type { UnaryCall } from "@protobuf-ts/runtime-rpc";
 import { stackIntercept } from "@protobuf-ts/runtime-rpc";
-import type { SubscribeIndexerResponse } from "./world";
-import type { SubscribeIndexerRequest } from "./world";
+import type { SubscribeContractsResponse } from "./world";
+import type { SubscribeContractsRequest } from "./world";
 import type { ServerStreamingCall } from "@protobuf-ts/runtime-rpc";
 import type { RpcOptions } from "@protobuf-ts/runtime-rpc";
 /**
@@ -54,11 +56,11 @@ import type { RpcOptions } from "@protobuf-ts/runtime-rpc";
  */
 export interface IWorldClient {
     /**
-     * Subscribes to updates about the indexer. Like the head block number, tps, etc.
+     * Subscribes to updates about contracts. Like the head block number, tps, etc.
      *
-     * @generated from protobuf rpc: SubscribeIndexer
+     * @generated from protobuf rpc: SubscribeContracts
      */
-    subscribeIndexer(input: SubscribeIndexerRequest, options?: RpcOptions): ServerStreamingCall<SubscribeIndexerRequest, SubscribeIndexerResponse>;
+    subscribeContracts(input: SubscribeContractsRequest, options?: RpcOptions): ServerStreamingCall<SubscribeContractsRequest, SubscribeContractsResponse>;
     /**
      * Retrieves metadata about the World including all the registered components and systems.
      *
@@ -168,6 +170,12 @@ export interface IWorldClient {
      */
     retrieveControllers(input: RetrieveControllersRequest, options?: RpcOptions): UnaryCall<RetrieveControllersRequest, RetrieveControllersResponse>;
     /**
+     * Retrieve contracts
+     *
+     * @generated from protobuf rpc: RetrieveContracts
+     */
+    retrieveContracts(input: RetrieveContractsRequest, options?: RpcOptions): UnaryCall<RetrieveContractsRequest, RetrieveContractsResponse>;
+    /**
      * Retrieve tokens collections
      *
      * @generated from protobuf rpc: RetrieveTokenCollections
@@ -198,13 +206,13 @@ export class WorldClient implements IWorldClient, ServiceInfo {
     constructor(private readonly _transport: RpcTransport) {
     }
     /**
-     * Subscribes to updates about the indexer. Like the head block number, tps, etc.
+     * Subscribes to updates about contracts. Like the head block number, tps, etc.
      *
-     * @generated from protobuf rpc: SubscribeIndexer
+     * @generated from protobuf rpc: SubscribeContracts
      */
-    subscribeIndexer(input: SubscribeIndexerRequest, options?: RpcOptions): ServerStreamingCall<SubscribeIndexerRequest, SubscribeIndexerResponse> {
+    subscribeContracts(input: SubscribeContractsRequest, options?: RpcOptions): ServerStreamingCall<SubscribeContractsRequest, SubscribeContractsResponse> {
         const method = this.methods[0], opt = this._transport.mergeOptions(options);
-        return stackIntercept<SubscribeIndexerRequest, SubscribeIndexerResponse>("serverStreaming", this._transport, method, opt, input);
+        return stackIntercept<SubscribeContractsRequest, SubscribeContractsResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
      * Retrieves metadata about the World including all the registered components and systems.
@@ -369,12 +377,21 @@ export class WorldClient implements IWorldClient, ServiceInfo {
         return stackIntercept<RetrieveControllersRequest, RetrieveControllersResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * Retrieve contracts
+     *
+     * @generated from protobuf rpc: RetrieveContracts
+     */
+    retrieveContracts(input: RetrieveContractsRequest, options?: RpcOptions): UnaryCall<RetrieveContractsRequest, RetrieveContractsResponse> {
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveContractsRequest, RetrieveContractsResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * Retrieve tokens collections
      *
      * @generated from protobuf rpc: RetrieveTokenCollections
      */
     retrieveTokenCollections(input: RetrieveTokenCollectionsRequest, options?: RpcOptions): UnaryCall<RetrieveTokenCollectionsRequest, RetrieveTokenCollectionsResponse> {
-        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveTokenCollectionsRequest, RetrieveTokenCollectionsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -383,7 +400,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: PublishMessage
      */
     publishMessage(input: PublishMessageRequest, options?: RpcOptions): UnaryCall<PublishMessageRequest, PublishMessageResponse> {
-        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
         return stackIntercept<PublishMessageRequest, PublishMessageResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -392,7 +409,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: PublishMessageBatch
      */
     publishMessageBatch(input: PublishMessageBatchRequest, options?: RpcOptions): UnaryCall<PublishMessageBatchRequest, PublishMessageBatchResponse> {
-        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<PublishMessageBatchRequest, PublishMessageBatchResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/packages/grpc/src/generated/world.ts
+++ b/packages/grpc/src/generated/world.ts
@@ -25,6 +25,8 @@ import { TokenBalanceQuery } from "./types";
 import { Token } from "./types";
 import { TokenQuery } from "./types";
 import { TokenBalance } from "./types";
+import { Contract } from "./types";
+import { ContractQuery } from "./types";
 import { Controller } from "./types";
 import { ControllerQuery } from "./types";
 import { Transaction } from "./types";
@@ -68,6 +70,24 @@ export interface RetrieveControllersResponse {
      * @generated from protobuf field: repeated types.Controller controllers = 2
      */
     controllers: Controller[];
+}
+/**
+ * @generated from protobuf message world.RetrieveContractsRequest
+ */
+export interface RetrieveContractsRequest {
+    /**
+     * @generated from protobuf field: types.ContractQuery query = 1
+     */
+    query?: ContractQuery;
+}
+/**
+ * @generated from protobuf message world.RetrieveContractsResponse
+ */
+export interface RetrieveContractsResponse {
+    /**
+     * @generated from protobuf field: repeated types.Contract contracts = 1
+     */
+    contracts: Contract[];
 }
 /**
  * A request to update a token balance subscription
@@ -312,38 +332,26 @@ export interface RetrieveTokenCollectionsResponse {
     tokens: TokenCollection[];
 }
 /**
- * A request to subscribe to indexer updates.
+ * A request to subscribe to contract updates.
  *
- * @generated from protobuf message world.SubscribeIndexerRequest
+ * @generated from protobuf message world.SubscribeContractsRequest
  */
-export interface SubscribeIndexerRequest {
+export interface SubscribeContractsRequest {
     /**
-     * @generated from protobuf field: bytes contract_address = 1
+     * @generated from protobuf field: types.ContractQuery query = 1
      */
-    contract_address: Uint8Array;
+    query?: ContractQuery;
 }
 /**
- * A response containing indexer updates.
+ * A response containing contract updates.
  *
- * @generated from protobuf message world.SubscribeIndexerResponse
+ * @generated from protobuf message world.SubscribeContractsResponse
  */
-export interface SubscribeIndexerResponse {
+export interface SubscribeContractsResponse {
     /**
-     * @generated from protobuf field: int64 head = 1
+     * @generated from protobuf field: types.Contract contract = 1
      */
-    head: bigint;
-    /**
-     * @generated from protobuf field: int64 tps = 2
-     */
-    tps: bigint;
-    /**
-     * @generated from protobuf field: int64 last_block_timestamp = 3
-     */
-    last_block_timestamp: bigint;
-    /**
-     * @generated from protobuf field: bytes contract_address = 4
-     */
-    contract_address: Uint8Array;
+    contract?: Contract;
 }
 /**
  * A request to retrieve metadata for a specific world ID.
@@ -730,6 +738,99 @@ class RetrieveControllersResponse$Type extends MessageType<RetrieveControllersRe
  * @generated MessageType for protobuf message world.RetrieveControllersResponse
  */
 export const RetrieveControllersResponse = new RetrieveControllersResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class RetrieveContractsRequest$Type extends MessageType<RetrieveContractsRequest> {
+    constructor() {
+        super("world.RetrieveContractsRequest", [
+            { no: 1, name: "query", kind: "message", T: () => ContractQuery }
+        ]);
+    }
+    create(value?: PartialMessage<RetrieveContractsRequest>): RetrieveContractsRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<RetrieveContractsRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveContractsRequest): RetrieveContractsRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* types.ContractQuery query */ 1:
+                    message.query = ContractQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: RetrieveContractsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* types.ContractQuery query = 1; */
+        if (message.query)
+            ContractQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message world.RetrieveContractsRequest
+ */
+export const RetrieveContractsRequest = new RetrieveContractsRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class RetrieveContractsResponse$Type extends MessageType<RetrieveContractsResponse> {
+    constructor() {
+        super("world.RetrieveContractsResponse", [
+            { no: 1, name: "contracts", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Contract }
+        ]);
+    }
+    create(value?: PartialMessage<RetrieveContractsResponse>): RetrieveContractsResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.contracts = [];
+        if (value !== undefined)
+            reflectionMergePartial<RetrieveContractsResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveContractsResponse): RetrieveContractsResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated types.Contract contracts */ 1:
+                    message.contracts.push(Contract.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: RetrieveContractsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated types.Contract contracts = 1; */
+        for (let i = 0; i < message.contracts.length; i++)
+            Contract.internalBinaryWrite(message.contracts[i], writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message world.RetrieveContractsResponse
+ */
+export const RetrieveContractsResponse = new RetrieveContractsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class UpdateTokenBalancesSubscriptionRequest$Type extends MessageType<UpdateTokenBalancesSubscriptionRequest> {
     constructor() {
@@ -1495,26 +1596,25 @@ class RetrieveTokenCollectionsResponse$Type extends MessageType<RetrieveTokenCol
  */
 export const RetrieveTokenCollectionsResponse = new RetrieveTokenCollectionsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class SubscribeIndexerRequest$Type extends MessageType<SubscribeIndexerRequest> {
+class SubscribeContractsRequest$Type extends MessageType<SubscribeContractsRequest> {
     constructor() {
-        super("world.SubscribeIndexerRequest", [
-            { no: 1, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ }
+        super("world.SubscribeContractsRequest", [
+            { no: 1, name: "query", kind: "message", T: () => ContractQuery }
         ]);
     }
-    create(value?: PartialMessage<SubscribeIndexerRequest>): SubscribeIndexerRequest {
+    create(value?: PartialMessage<SubscribeContractsRequest>): SubscribeContractsRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.contract_address = new Uint8Array(0);
         if (value !== undefined)
-            reflectionMergePartial<SubscribeIndexerRequest>(this, message, value);
+            reflectionMergePartial<SubscribeContractsRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeIndexerRequest): SubscribeIndexerRequest {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeContractsRequest): SubscribeContractsRequest {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* bytes contract_address */ 1:
-                    message.contract_address = reader.bytes();
+                case /* types.ContractQuery query */ 1:
+                    message.query = ContractQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1527,10 +1627,10 @@ class SubscribeIndexerRequest$Type extends MessageType<SubscribeIndexerRequest> 
         }
         return message;
     }
-    internalBinaryWrite(message: SubscribeIndexerRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* bytes contract_address = 1; */
-        if (message.contract_address.length)
-            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_address);
+    internalBinaryWrite(message: SubscribeContractsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* types.ContractQuery query = 1; */
+        if (message.query)
+            ContractQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1538,45 +1638,29 @@ class SubscribeIndexerRequest$Type extends MessageType<SubscribeIndexerRequest> 
     }
 }
 /**
- * @generated MessageType for protobuf message world.SubscribeIndexerRequest
+ * @generated MessageType for protobuf message world.SubscribeContractsRequest
  */
-export const SubscribeIndexerRequest = new SubscribeIndexerRequest$Type();
+export const SubscribeContractsRequest = new SubscribeContractsRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class SubscribeIndexerResponse$Type extends MessageType<SubscribeIndexerResponse> {
+class SubscribeContractsResponse$Type extends MessageType<SubscribeContractsResponse> {
     constructor() {
-        super("world.SubscribeIndexerResponse", [
-            { no: 1, name: "head", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 2, name: "tps", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 3, name: "last_block_timestamp", kind: "scalar", localName: "last_block_timestamp", T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
-            { no: 4, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ }
+        super("world.SubscribeContractsResponse", [
+            { no: 1, name: "contract", kind: "message", T: () => Contract }
         ]);
     }
-    create(value?: PartialMessage<SubscribeIndexerResponse>): SubscribeIndexerResponse {
+    create(value?: PartialMessage<SubscribeContractsResponse>): SubscribeContractsResponse {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.head = 0n;
-        message.tps = 0n;
-        message.last_block_timestamp = 0n;
-        message.contract_address = new Uint8Array(0);
         if (value !== undefined)
-            reflectionMergePartial<SubscribeIndexerResponse>(this, message, value);
+            reflectionMergePartial<SubscribeContractsResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeIndexerResponse): SubscribeIndexerResponse {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeContractsResponse): SubscribeContractsResponse {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* int64 head */ 1:
-                    message.head = reader.int64().toBigInt();
-                    break;
-                case /* int64 tps */ 2:
-                    message.tps = reader.int64().toBigInt();
-                    break;
-                case /* int64 last_block_timestamp */ 3:
-                    message.last_block_timestamp = reader.int64().toBigInt();
-                    break;
-                case /* bytes contract_address */ 4:
-                    message.contract_address = reader.bytes();
+                case /* types.Contract contract */ 1:
+                    message.contract = Contract.internalBinaryRead(reader, reader.uint32(), options, message.contract);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1589,19 +1673,10 @@ class SubscribeIndexerResponse$Type extends MessageType<SubscribeIndexerResponse
         }
         return message;
     }
-    internalBinaryWrite(message: SubscribeIndexerResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* int64 head = 1; */
-        if (message.head !== 0n)
-            writer.tag(1, WireType.Varint).int64(message.head);
-        /* int64 tps = 2; */
-        if (message.tps !== 0n)
-            writer.tag(2, WireType.Varint).int64(message.tps);
-        /* int64 last_block_timestamp = 3; */
-        if (message.last_block_timestamp !== 0n)
-            writer.tag(3, WireType.Varint).int64(message.last_block_timestamp);
-        /* bytes contract_address = 4; */
-        if (message.contract_address.length)
-            writer.tag(4, WireType.LengthDelimited).bytes(message.contract_address);
+    internalBinaryWrite(message: SubscribeContractsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* types.Contract contract = 1; */
+        if (message.contract)
+            Contract.internalBinaryWrite(message.contract, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1609,9 +1684,9 @@ class SubscribeIndexerResponse$Type extends MessageType<SubscribeIndexerResponse
     }
 }
 /**
- * @generated MessageType for protobuf message world.SubscribeIndexerResponse
+ * @generated MessageType for protobuf message world.SubscribeContractsResponse
  */
-export const SubscribeIndexerResponse = new SubscribeIndexerResponse$Type();
+export const SubscribeContractsResponse = new SubscribeContractsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class WorldMetadataRequest$Type extends MessageType<WorldMetadataRequest> {
     constructor() {
@@ -2491,7 +2566,7 @@ export const PublishMessageBatchResponse = new PublishMessageBatchResponse$Type(
  * @generated ServiceType for protobuf service world.World
  */
 export const World = new ServiceType("world.World", [
-    { name: "SubscribeIndexer", serverStreaming: true, options: {}, I: SubscribeIndexerRequest, O: SubscribeIndexerResponse },
+    { name: "SubscribeContracts", serverStreaming: true, options: {}, I: SubscribeContractsRequest, O: SubscribeContractsResponse },
     { name: "WorldMetadata", options: {}, I: WorldMetadataRequest, O: WorldMetadataResponse },
     { name: "SubscribeEntities", serverStreaming: true, options: {}, I: SubscribeEntitiesRequest, O: SubscribeEntityResponse },
     { name: "UpdateEntitiesSubscription", options: {}, I: UpdateEntitiesSubscriptionRequest, O: Empty },
@@ -2510,6 +2585,7 @@ export const World = new ServiceType("world.World", [
     { name: "RetrieveTransactions", options: {}, I: RetrieveTransactionsRequest, O: RetrieveTransactionsResponse },
     { name: "SubscribeTransactions", serverStreaming: true, options: {}, I: SubscribeTransactionsRequest, O: SubscribeTransactionsResponse },
     { name: "RetrieveControllers", options: {}, I: RetrieveControllersRequest, O: RetrieveControllersResponse },
+    { name: "RetrieveContracts", options: {}, I: RetrieveContractsRequest, O: RetrieveContractsResponse },
     { name: "RetrieveTokenCollections", options: {}, I: RetrieveTokenCollectionsRequest, O: RetrieveTokenCollectionsResponse },
     { name: "PublishMessage", options: {}, I: PublishMessageRequest, O: PublishMessageResponse },
     { name: "PublishMessageBatch", options: {}, I: PublishMessageBatchRequest, O: PublishMessageBatchResponse }

--- a/packages/grpc/src/index.ts
+++ b/packages/grpc/src/index.ts
@@ -31,6 +31,8 @@ export type {
     Transaction,
     TransactionFilter,
     TransactionQuery,
+    Contract,
+    ContractQuery,
     // World is intentionally excluded to avoid conflict
 } from "./generated/types";
 
@@ -42,6 +44,7 @@ export {
     OrderDirection,
     CallType,
     PaginationDirection,
+    ContractType,
 } from "./generated/types";
 
 // Re-export world proto types (excluding the World service)
@@ -64,8 +67,10 @@ export type {
     RetrieveTransactionsResponse,
     RetrieveTokenCollectionsRequest,
     RetrieveTokenCollectionsResponse,
-    SubscribeIndexerRequest,
-    SubscribeIndexerResponse,
+    RetrieveContractsRequest,
+    RetrieveContractsResponse,
+    SubscribeContractsRequest,
+    SubscribeContractsResponse,
     WorldMetadataRequest,
     WorldMetadataResponse,
     SubscribeEntitiesRequest,

--- a/packages/grpc/src/mappings/effect-schema/transformers.ts
+++ b/packages/grpc/src/mappings/effect-schema/transformers.ts
@@ -107,3 +107,75 @@ export function transformMessage(
         ),
     };
 }
+
+export function transformEvent(event: any): any {
+    return {
+        keys: event.keys.map((key: Uint8Array) =>
+            Schema.decodeSync(BufferToHex)(key)
+        ),
+        data: event.data.map((d: Uint8Array) =>
+            Schema.decodeSync(BufferToHex)(d)
+        ),
+        transaction_hash: Schema.decodeSync(BufferToHex)(
+            event.transaction_hash
+        ),
+    };
+}
+
+export function transformEventsResponse(response: any): any {
+    return {
+        items: response.events.map(transformEvent),
+        next_cursor: response.next_cursor || undefined,
+    };
+}
+
+export function transformContract(contract: any): any {
+    return {
+        contract_address: Schema.decodeSync(BufferToHex)(
+            contract.contract_address
+        ),
+        contract_type: contract.contract_type,
+        head: contract.head ? Number(contract.head) : undefined,
+        tps: contract.tps ? Number(contract.tps) : undefined,
+        last_block_timestamp: contract.last_block_timestamp
+            ? Number(contract.last_block_timestamp)
+            : undefined,
+        last_pending_block_tx: contract.last_pending_block_tx
+            ? Schema.decodeSync(BufferToHex)(contract.last_pending_block_tx)
+            : undefined,
+        updated_at: Number(contract.updated_at),
+        created_at: Number(contract.created_at),
+    };
+}
+
+export function transformContractsResponse(response: any): any {
+    return {
+        items: response.contracts.map(transformContract),
+    };
+}
+
+export function transformWorldMetadataResponse(response: any): any {
+    if (!response.world) {
+        return null;
+    }
+
+    return {
+        world_address: Schema.decodeSync(BufferToHex)(
+            response.world.world_address
+        ),
+        models: response.world.models.map((model: any) => ({
+            selector: Schema.decodeSync(BufferToHex)(model.selector),
+            namespace: model.namespace,
+            name: model.name,
+            packed_size: model.packed_size,
+            unpacked_size: model.unpacked_size,
+            class_hash: Schema.decodeSync(BufferToHex)(model.class_hash),
+            layout: Schema.decodeSync(BufferToHex)(model.layout),
+            schema: Schema.decodeSync(BufferToHex)(model.schema),
+            contract_address: Schema.decodeSync(BufferToHex)(
+                model.contract_address
+            ),
+            use_legacy_store: model.use_legacy_store,
+        })),
+    };
+}

--- a/packages/grpc/src/mappings/query.ts
+++ b/packages/grpc/src/mappings/query.ts
@@ -13,6 +13,7 @@ import type {
     TokenBalanceQuery as ToriiTokenBalanceQuery,
     TransactionQuery as ToriiTransactionQuery,
     TransactionFilter as ToriiTransactionFilter,
+    KeysClause as ToriiKeysClause,
 } from "@dojoengine/torii-wasm";
 
 import type {
@@ -30,6 +31,8 @@ import type {
     TokenBalanceQuery as GrpcTokenBalanceQuery,
     TransactionQuery as GrpcTransactionQuery,
     TransactionFilter as GrpcTransactionFilter,
+    EventQuery as GrpcEventQuery,
+    ContractQuery as GrpcContractQuery,
 } from "../generated/types";
 
 import {
@@ -48,6 +51,8 @@ import type {
     RetrieveTokenCollectionsRequest,
     RetrieveControllersRequest,
     RetrieveTransactionsRequest,
+    RetrieveEventsRequest,
+    RetrieveContractsRequest,
 } from "../generated/world";
 
 function hexToBuffer(hex: string): Uint8Array {
@@ -335,5 +340,43 @@ export function createRetrieveTransactionsRequest(
 ): RetrieveTransactionsRequest {
     return {
         query: mapTransactionQuery(query),
+    };
+}
+
+export function createRetrieveEventsRequest(query: {
+    keys?: ToriiKeysClause;
+    pagination?: ToriiPagination;
+}): RetrieveEventsRequest {
+    return {
+        query: {
+            keys: query.keys
+                ? {
+                      keys: query.keys.keys.map((k) =>
+                          k ? hexToBuffer(k) : new Uint8Array()
+                      ),
+                      pattern_matching:
+                          query.keys.pattern_matching === "FixedLen"
+                              ? GrpcPatternMatching.FixedLen
+                              : GrpcPatternMatching.VariableLen,
+                      models: query.keys.models || [],
+                  }
+                : undefined,
+            pagination: query.pagination
+                ? mapPagination(query.pagination)
+                : undefined,
+        },
+    };
+}
+
+export function createRetrieveContractsRequest(query: {
+    contract_addresses?: string[];
+    contract_types?: any[];
+}): RetrieveContractsRequest {
+    return {
+        query: {
+            contract_addresses:
+                query.contract_addresses?.map(hexToBuffer) || [],
+            contract_types: query.contract_types || [],
+        },
     };
 }

--- a/packages/internal/CHANGELOG.md
+++ b/packages/internal/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @dojoengine/internal
 
+## 1.6.8-preview.0
+
+### Patch Changes
+
+- 4060bc6: feat(grpc): upgrade torii to preview.6
+- Updated dependencies [4060bc6]
+  - @dojoengine/torii-wasm@1.7.1-preview.0
+  - @dojoengine/torii-client@1.7.1-preview.0
+
 ## 1.6.7
 
 ### Patch Changes

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dojoengine/internal",
-    "version": "1.6.7",
+    "version": "1.6.8-preview.0",
     "private": true,
     "description": "Internal APIs for Dojo Engine packages",
     "author": "Dojo Team",

--- a/packages/internal/src/token.ts
+++ b/packages/internal/src/token.ts
@@ -198,6 +198,7 @@ export const defaultToken: torii.Token = {
     symbol: "",
     decimals: 0,
     metadata: "",
+    total_supply: "",
 };
 
 /**

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.7.1-preview.0
+
+### Patch Changes
+
+- @dojoengine/torii-client@1.7.1-preview.0
+- @dojoengine/state@1.7.1-preview.0
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dojoengine/react",
-    "version": "1.7.0",
+    "version": "1.7.1-preview.0",
     "description": "dojo: React hooks for working with the dojo engine stack.",
     "author": "dojo",
     "source": "src/index.ts",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 1.7.1-preview.0
+
+### Patch Changes
+
+- Updated dependencies [4060bc6]
+  - @dojoengine/torii-wasm@1.7.1-preview.0
+  - @dojoengine/grpc@1.7.1-preview.0
+  - @dojoengine/torii-client@1.7.1-preview.0
+  - @dojoengine/state@1.7.1-preview.0
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dojoengine/sdk",
-    "version": "1.7.0",
+    "version": "1.7.1-preview.0",
     "description": "Dojo SDK: Build onchain and provable apps faster",
     "author": "Dojo Team",
     "license": "MIT",

--- a/packages/state/CHANGELOG.md
+++ b/packages/state/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.7.1-preview.0
+
+### Patch Changes
+
+- @dojoengine/torii-client@1.7.1-preview.0
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dojoengine/state",
-    "version": "1.7.0",
+    "version": "1.7.1-preview.0",
     "description": "dojo: State syncing for dojo games",
     "author": "dojo",
     "license": "MIT",

--- a/packages/torii-client/CHANGELOG.md
+++ b/packages/torii-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.7.1-preview.0
+
+### Patch Changes
+
+- Updated dependencies [4060bc6]
+  - @dojoengine/torii-wasm@1.7.1-preview.0
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/torii-client/package.json
+++ b/packages/torii-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dojoengine/torii-client",
-    "version": "1.7.0",
+    "version": "1.7.1-preview.0",
     "description": "dojo: package bundles torii wasm into a helpful export for web",
     "author": "dojo",
     "license": "MIT",

--- a/packages/torii-wasm/CHANGELOG.md
+++ b/packages/torii-wasm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.7.1-preview.0
+
+### Patch Changes
+
+- 4060bc6: feat(grpc): upgrade torii to preview.6
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/torii-wasm/package.json
+++ b/packages/torii-wasm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dojoengine/torii-wasm",
-    "version": "1.7.0",
+    "version": "1.7.1-preview.0",
     "description": "dojo: WASM bindings for torii",
     "author": "ohayo",
     "license": "MIT",


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve world metadata, events, and contracts via new query APIs.
  * Subscribe to contract updates with filtering by addresses and types.
  * View token total supply in responses.
  * Enhanced array query operators (contains, contains_all/any, array_length eq/gt/lt).
  * Support for fixed-size array types in schemas.
  * Added contract metadata (address, type, head, TPS, timestamps, pending tx).

* **Refactor**
  * Replaced indexer-based subscription with contracts-focused subscription and retrieval.
  * Added entity/contract timestamps and a legacy-store flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->