### PR TITLE
chore: bump torii to 1.7.0

### DIFF
--- a/.changeset/orange-actors-mix.md
+++ b/.changeset/orange-actors-mix.md
@@ -1,0 +1,17 @@
+---
+"@dojoengine/torii-wasm": patch
+"@dojoengine/internal": patch
+"@dojoengine/sdk": patch
+"@dojoengine/core": patch
+"@dojoengine/create-burner": patch
+"@dojoengine/create-dojo": patch
+"@dojoengine/grpc": patch
+"@dojoengine/predeployed-connector": patch
+"@dojoengine/react": patch
+"@dojoengine/state": patch
+"@dojoengine/torii-client": patch
+"@dojoengine/utils": patch
+"@dojoengine/utils-wasm": patch
+---
+
+chore: update torii to 1.7.0

--- a/packages/internal/src/types.ts
+++ b/packages/internal/src/types.ts
@@ -124,11 +124,17 @@ export type SubscribeResponse<T extends SchemaType> = [
     torii.Subscription,
 ];
 
+export type AttributesFilter = {
+    name: string;
+    value: string;
+};
+
 /**
  * Request type for getting tokens.
  */
 export interface GetTokenRequest {
     contractAddresses?: string[];
+    attributesFilter?: AttributesFilter[];
     tokenIds?: string[];
     pagination?: torii.Pagination;
 }
@@ -139,6 +145,20 @@ export interface GetTokenRequest {
 export interface GetTokenBalanceRequest extends GetTokenRequest {
     accountAddresses?: string[];
 }
+
+export type ContractType =
+    | "WORLD"
+    | "ERC20"
+    | "ERC721"
+    | "ERC1155"
+    | "UDC"
+    | "OTHER";
+
+export type GetTokenContracts = {
+    contractAddresses?: string[];
+    contractTypes?: string[];
+    pagination?: torii.Pagination;
+};
 
 /**
  * Success result for subscription callbacks.
@@ -373,6 +393,16 @@ export interface SDK<T extends SchemaType> {
      * @returns {Promise<torii.Tokens>} - Token information
      */
     getTokens(request: GetTokenRequest): Promise<torii.Tokens>;
+
+    /**
+     * Gets token contracts.
+     *
+     * @param {GetTokenContracts} request - Filter parameters
+     * @returns {Promise<torii.TokenContracts>} - Token information
+     */
+    getTokenContracts(
+        request: GetTokenContracts
+    ): Promise<torii.TokenContracts>;
 
     /**
      * Gets token balances for specified accounts.

--- a/packages/sdk/src/createSDK.ts
+++ b/packages/sdk/src/createSDK.ts
@@ -16,11 +16,13 @@ import {
     subscribeTokenBalance,
     updateTokenBalanceSubscription,
     defaultToken,
+    getTokenContracts,
 } from "@dojoengine/internal";
 import type {
     GetParams,
     GetTokenBalanceRequest,
     GetTokenRequest,
+    GetTokenContracts,
     SchemaType,
     SDK,
     SDKConfig,
@@ -63,6 +65,12 @@ export interface GrpcClientInterface {
         token_ids?: any[];
         pagination?: torii.Pagination;
     }): Promise<torii.Tokens>;
+    // Token operations
+    getTokenContracts(params: {
+        contract_addresses?: string[];
+        contract_types?: torii.ContractType[];
+        pagination?: torii.Pagination;
+    }): Promise<torii.TokenContracts>;
     getTokenBalances(params: {
         contract_addresses?: string[];
         account_addresses?: string[];
@@ -336,6 +344,27 @@ export function createSDK<T extends SchemaType>({
                 });
             }
             return await getTokens(client!, request);
+        },
+
+        /**
+         * Gets tokens based on the provided request.
+         *
+         * @param {GetTokenContracts} request
+         * @returns {Promise<torii.Tokens>}
+         */
+        getTokenContracts: async (
+            request: GetTokenContracts
+        ): Promise<torii.TokenContracts> => {
+            if (grpcClient) {
+                const { contractAddresses, contractTypes, pagination } =
+                    parseTokenRequest(request);
+                return await grpcClient.getTokenContracts({
+                    contract_addresses: contractAddresses,
+                    contract_types: contractTypes as torii.ContractType[],
+                    pagination,
+                });
+            }
+            return await getTokenContracts(client!, request);
         },
 
         /**


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added token attribute filtering to refine token queries.
  - Introduced a new capability to fetch token contract metadata by addresses and types, with pagination support.

- Chores
  - Updated dependencies, including bumping torii to version 1.7.0.
  - Synchronized internal WASM submodule to the latest commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->