### PR TITLE
feat(types): extend ABI tooling for schema generation

### DIFF
--- a/.changeset/mighty-feet-move.md
+++ b/.changeset/mighty-feet-move.md
@@ -1,0 +1,5 @@
+---
+"@dojoengine/core": patch
+---
+
+feat(core): add ABI tooling for schema generation

--- a/packages/core/src/cli/compile-abi.ts
+++ b/packages/core/src/cli/compile-abi.ts
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync, readdirSync, existsSync } from "fs";
-import { join } from "path";
+import {
+    readFileSync,
+    writeFileSync,
+    readdirSync,
+    existsSync,
+    mkdirSync,
+} from "fs";
+import { join, isAbsolute, dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+import type { Dirent } from "fs";
 
 type AbiEntry = {
     [key: string]: any;
@@ -26,13 +34,41 @@ type TargetFile = {
     [key: string]: any;
 };
 
+type OutputPaths = {
+    json: string;
+    ts: string;
+};
+
+type CollectOptions = {
+    generateTypes: boolean;
+    outputPath?: string;
+};
+
 /**
  * Generate a TypeScript file from compiled-abi.json with proper const assertions
  * This allows TypeScript to extract literal types from the ABI
  */
-function generateAbiTypes(dojoRoot: string): void {
-    const inputPath = join(dojoRoot, "compiled-abi.json");
-    const outputPath = join(dojoRoot, "compiled-abi.ts");
+function ensureDirectory(path: string): void {
+    const directory = dirname(path);
+    mkdirSync(directory, { recursive: true });
+}
+
+export function resolveOutputPaths(outputOption?: string): OutputPaths {
+    const jsonPath = outputOption
+        ? isAbsolute(outputOption)
+            ? outputOption
+            : join(process.cwd(), outputOption)
+        : join(process.cwd(), "compiled-abi.json");
+
+    const tsPath = jsonPath.endsWith(".json")
+        ? `${jsonPath.slice(0, -5)}.ts`
+        : `${jsonPath}.ts`;
+
+    return { json: jsonPath, ts: tsPath };
+}
+
+function generateAbiTypes(paths: OutputPaths): void {
+    const { json: inputPath, ts: outputPath } = paths;
 
     try {
         // Read the compiled ABI
@@ -49,14 +85,18 @@ export type CompiledAbi = typeof compiledAbi;
 `;
 
         // Write the TypeScript file
+        ensureDirectory(outputPath);
         writeFileSync(outputPath, tsContent);
 
         console.log(`✅ Generated TypeScript types!`);
-        console.log(`📄 Output written to: ${outputPath}`);
-        console.log(`\nUsage in your code:`);
-        console.log(`\nimport { compiledAbi } from './compiled-abi';`);
+        console.log(`📄 Type output written to: ${outputPath}`);
+        console.log(`
+Usage in your code:`);
+        console.log(`
+import { compiledAbi } from './compiled-abi';`);
         console.log(`import { ExtractAbiTypes } from '@dojoengine/core';`);
-        console.log(`\ntype MyAbi = ExtractAbiTypes<typeof compiledAbi>;`);
+        console.log(`
+type MyAbi = ExtractAbiTypes<typeof compiledAbi>;`);
         console.log(
             `type Position = MyAbi["structs"]["dojo_starter::models::Position"];`
         );
@@ -66,7 +106,27 @@ export type CompiledAbi = typeof compiledAbi;
     }
 }
 
-function collectAbis(generateTypes: boolean): void {
+function walkJsonFiles(root: string, entries: Dirent[] = []): string[] {
+    const collected: string[] = [];
+
+    for (const entry of entries) {
+        const fullPath = join(root, entry.name);
+
+        if (entry.isDirectory()) {
+            const childEntries = readdirSync(fullPath, { withFileTypes: true });
+            collected.push(...walkJsonFiles(fullPath, childEntries));
+            continue;
+        }
+
+        if (entry.isFile() && entry.name.endsWith(".json")) {
+            collected.push(fullPath);
+        }
+    }
+
+    return collected;
+}
+
+function collectAbis(options: CollectOptions): void {
     const dojoRoot = process.env.DOJO_ROOT || process.cwd();
     const dojoEnv = process.env.DOJO_ENV || "dev";
 
@@ -74,6 +134,7 @@ function collectAbis(generateTypes: boolean): void {
     const targetDir = join(dojoRoot, "target", dojoEnv);
 
     const allAbis: AbiEntry[] = [];
+    let manifest: Manifest | null = null;
 
     // Read manifest file
     if (!existsSync(manifestPath)) {
@@ -83,7 +144,7 @@ function collectAbis(generateTypes: boolean): void {
 
     try {
         const manifestContent = readFileSync(manifestPath, "utf-8");
-        const manifest: Manifest = JSON.parse(manifestContent);
+        manifest = JSON.parse(manifestContent) as Manifest;
 
         // Extract ABIs from world
         if (manifest.world?.abi) {
@@ -108,12 +169,10 @@ function collectAbis(generateTypes: boolean): void {
         console.warn(`Target directory not found: ${targetDir}`);
     } else {
         try {
-            const files = readdirSync(targetDir).filter((file) =>
-                file.endsWith(".json")
-            );
+            const dirEntries = readdirSync(targetDir, { withFileTypes: true });
+            const files = walkJsonFiles(targetDir, dirEntries);
 
-            for (const file of files) {
-                const filePath = join(targetDir, file);
+            for (const filePath of files) {
                 try {
                     const fileContent = readFileSync(filePath, "utf-8");
                     const targetFile: TargetFile = JSON.parse(fileContent);
@@ -123,7 +182,7 @@ function collectAbis(generateTypes: boolean): void {
                         allAbis.push(...targetFile.abi);
                     }
                 } catch (error) {
-                    console.error(`Error reading file ${file}: ${error}`);
+                    console.error(`Error reading file ${filePath}: ${error}`);
                 }
             }
         } catch (error) {
@@ -131,32 +190,134 @@ function collectAbis(generateTypes: boolean): void {
         }
     }
 
+    const dedupedAbis = new Map<string, AbiEntry>();
+    const duplicateCounts: Record<string, number> = {};
+
+    for (const entry of allAbis) {
+        const type = typeof entry.type === "string" ? entry.type : "unknown";
+        const name =
+            typeof (entry as { name?: string }).name === "string"
+                ? (entry as { name: string }).name
+                : "";
+        const interfaceName =
+            typeof (entry as { interface_name?: string }).interface_name ===
+            "string"
+                ? (entry as { interface_name: string }).interface_name
+                : "";
+
+        const key = `${type}::${name}::${interfaceName}`;
+
+        if (dedupedAbis.has(key)) {
+            duplicateCounts[key] = (duplicateCounts[key] ?? 1) + 1;
+            continue;
+        }
+
+        dedupedAbis.set(key, entry);
+    }
+
+    const mergedAbis = Array.from(dedupedAbis.entries())
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([, value]) => value);
+
+    if (Object.keys(duplicateCounts).length > 0) {
+        console.warn("!  Duplicate ABI entries detected and ignored:");
+        for (const [key, count] of Object.entries(duplicateCounts)) {
+            console.warn(`   • ${key} (${count} occurrences)`);
+        }
+    }
+
     // Write output
     const output = {
-        abi: allAbis,
+        abi: mergedAbis,
+        manifest: manifest && {
+            world: manifest.world,
+            base: manifest.base,
+            contracts: manifest.contracts ?? [],
+            models: manifest.models ?? [],
+        },
     };
 
-    const outputPath = join(dojoRoot, "compiled-abi.json");
-    writeFileSync(outputPath, JSON.stringify(output, null, 2));
+    const paths = resolveOutputPaths(options.outputPath);
+    ensureDirectory(paths.json);
+    writeFileSync(paths.json, JSON.stringify(output, null, 2));
 
     console.log(`✅ ABI compilation complete!`);
-    console.log(`📄 Output written to: ${outputPath}`);
-    console.log(`📊 Total ABI entries: ${allAbis.length}`);
+    console.log(`📄 Output written to: ${paths.json}`);
+    console.log(`📊 Total ABI entries: ${mergedAbis.length}`);
+
+    const typeStats = mergedAbis.reduce<Record<string, number>>((acc, item) => {
+        const key = typeof item.type === "string" ? item.type : "unknown";
+        acc[key] = (acc[key] ?? 0) + 1;
+        return acc;
+    }, {});
+
+    for (const [abiType, count] of Object.entries(typeStats)) {
+        console.log(`   • ${abiType}: ${count}`);
+    }
 
     // Generate TypeScript types if requested
-    if (generateTypes) {
-        generateAbiTypes(dojoRoot);
+    if (options.generateTypes) {
+        generateAbiTypes(paths);
     }
 }
 
-// Parse command line arguments
-const args = process.argv.slice(2);
-const generateTypes = args.includes("--generate-types");
+function parseArgs(argv: string[]): CollectOptions {
+    let generateTypes = false;
+    let outputPath: string | undefined;
+    let index = 0;
 
-// Run the compilation
-try {
-    collectAbis(generateTypes);
-} catch (error) {
-    console.error(`Unexpected error: ${error}`);
-    process.exit(1);
+    while (index < argv.length) {
+        const arg = argv[index];
+
+        if (arg === "--generate-types") {
+            generateTypes = true;
+            index += 1;
+            continue;
+        }
+
+        if (arg === "--output") {
+            const value = argv[index + 1];
+            if (!value || value.startsWith("--")) {
+                console.error("Missing value for --output option");
+                process.exit(1);
+            }
+            outputPath = value;
+            index += 2;
+            continue;
+        }
+
+        if (arg.startsWith("--output=")) {
+            const value = arg.slice("--output=".length);
+            if (!value) {
+                console.error("Missing value for --output option");
+                process.exit(1);
+            }
+            outputPath = value;
+            index += 1;
+            continue;
+        }
+
+        console.warn(`!  Unknown argument ignored: ${arg}`);
+        index += 1;
+    }
+
+    return {
+        generateTypes,
+        outputPath,
+    };
+}
+
+const __filename = resolve(fileURLToPath(import.meta.url));
+const entryPoint = process.argv[1] ? resolve(process.argv[1]) : undefined;
+const isDirectExecution = entryPoint === __filename;
+
+if (isDirectExecution) {
+    const options = parseArgs(process.argv.slice(2));
+
+    try {
+        collectAbis(options);
+    } catch (error) {
+        console.error(`Unexpected error: ${error}`);
+        process.exit(1);
+    }
 }

--- a/packages/core/src/types/example-usage.ts
+++ b/packages/core/src/types/example-usage.ts
@@ -1,13 +1,17 @@
-import { ExtractAbiTypes } from "./index";
+import {
+    ExtractAbiTypes,
+    ModelsFromAbi,
+    GetModel,
+    GetActionFunction,
+} from "./index";
 
 // Solution 1: Import the generated TypeScript file instead
-import {
-    CompiledAbi,
-    compiledAbi,
-} from "../../../../worlds/dojo-starter/compiled-abi";
+// import { compiledAbi } from "../../../../worlds/dojo-starter/compiled-abi";
+import { compiledAbi } from "./nums_dev";
 
 // Extract ABI types from the TypeScript version (this works!)
 type MyAbi = ExtractAbiTypes<typeof compiledAbi>;
+type Schema = ModelsFromAbi<typeof compiledAbi>;
 
 // Note: If you need the JSON at runtime, you can still import it separately
 // The types come from the TypeScript file, the runtime data from JSON
@@ -31,9 +35,9 @@ type MyAbiFunctions = MyAbi["functions"];
 type MyAbiInterfaces = MyAbi["interfaces"];
 
 // Now you can use the extracted types
-type Vec2 = MyAbi["structs"]["dojo_starter::models::Vec2"]; // { x: number; y: number }
-type Position = MyAbi["structs"]["dojo_starter::models::Position"]; // { player: string; vec: Vec2 }
-type PositionCount = MyAbi["structs"]["dojo_starter::models::PositionCount"];
+type Vec2 = Schema["dojo_starter"]["Vec2"];
+type Position = GetModel<typeof compiledAbi, "dojo_starter-Position">;
+type PositionCount = Schema["dojo_starter"]["PositionCount"];
 
 // Note: Nested struct references are resolved through the ABI context.
 // The type system now supports cross-references between structs in the same ABI.
@@ -53,9 +57,12 @@ type WorldResourceFunction = IWorld["resource"]; // { inputs: { selector: string
 type WorldUuidFunction = IWorld["uuid"]; // { inputs: {}, outputs: number }
 
 // Action interface example
-type IActions = MyAbi["interfaces"]["dojo_starter::systems::actions::IActions"];
-type SpawnFunction = IActions["spawn"]; // { inputs: {}, outputs: void }
-type MoveFunction = IActions["move"]; // { inputs: { direction: Direction["type"] }, outputs: void }
+type MoveFunction = GetActionFunction<
+    typeof compiledAbi,
+    "dojo_starter",
+    "IActions",
+    "move"
+>; // { inputs: { direction: Direction["type"] }, outputs: void }
 
 // To make this work with your actual compiled-abi.json, you need to:
 // 1. Create a script that converts compiled-abi.json to a TypeScript file with proper const assertions

--- a/packages/core/src/types/index.test.ts
+++ b/packages/core/src/types/index.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expectTypeOf } from "vitest";
+import {
+    ExtractAbiTypes,
+    ModelPathFromAbi,
+    GetModel,
+    ModelsFromAbi,
+    ActionsFromAbi,
+    GetActionFunction,
+} from "./index";
+
+const sampleAbi = {
+    abi: [
+        {
+            type: "struct",
+            name: "demo::models::Player",
+            members: [
+                { name: "id", type: "core::felt252" },
+                { name: "score", type: "core::integer::u32" },
+            ],
+        },
+        {
+            type: "struct",
+            name: "demo::models::Position",
+            members: [
+                { name: "player", type: "demo::models::Player" },
+                { name: "x", type: "core::integer::u16" },
+                { name: "y", type: "core::integer::u16" },
+            ],
+        },
+        {
+            type: "enum",
+            name: "demo::models::Direction",
+            variants: [
+                { name: "Up", type: "()" },
+                { name: "Down", type: "()" },
+                { name: "Left", type: "()" },
+                { name: "Right", type: "()" },
+            ],
+        },
+        {
+            type: "function",
+            name: "move",
+            inputs: [
+                { name: "entity", type: "demo::models::Position" },
+                { name: "direction", type: "demo::models::Direction" },
+            ],
+            outputs: [{ type: "()" }],
+        },
+        {
+            type: "interface",
+            name: "demo::systems::actions::IActions",
+            items: [
+                {
+                    type: "function",
+                    name: "move",
+                    inputs: [
+                        { name: "entity", type: "demo::models::Position" },
+                        { name: "direction", type: "demo::models::Direction" },
+                    ],
+                    outputs: [{ type: "()" }],
+                    state_mutability: "external",
+                },
+            ],
+        },
+    ],
+} as const;
+
+type Extracted = ExtractAbiTypes<typeof sampleAbi>;
+
+describe("ExtractAbiTypes", () => {
+    it("maps Cairo structs to TypeScript models", () => {
+        expectTypeOf<
+            Extracted["structs"]["demo::models::Player"]
+        >().toEqualTypeOf<{
+            id: string;
+            score: number;
+        }>();
+
+        expectTypeOf<Extracted["models"]["demo"]["Position"]>().toEqualTypeOf<{
+            player: Extracted["models"]["demo"]["Player"];
+            x: number;
+            y: number;
+        }>();
+    });
+
+    it("provides model paths and lookups", () => {
+        type Paths = ModelPathFromAbi<typeof sampleAbi>;
+        expectTypeOf<Paths>().toEqualTypeOf<"demo-Player" | "demo-Position">();
+
+        expectTypeOf<
+            GetModel<typeof sampleAbi, "demo-Player">
+        >().toEqualTypeOf<{
+            id: string;
+            score: number;
+        }>();
+    });
+
+    it("exposes enums and actions with typed members", () => {
+        expectTypeOf<
+            Extracted["enums"]["demo::models::Direction"]["type"]
+        >().toEqualTypeOf<"Up" | "Down" | "Left" | "Right">();
+
+        type Actions = ActionsFromAbi<typeof sampleAbi>;
+        expectTypeOf<keyof Actions>().toEqualTypeOf<"demo">();
+        expectTypeOf<keyof Actions["demo"]>().toEqualTypeOf<"IActions">();
+
+        type Move = GetActionFunction<
+            typeof sampleAbi,
+            "demo",
+            "IActions",
+            "move"
+        >;
+
+        expectTypeOf<Move["inputs"]>().toEqualTypeOf<{
+            entity: ModelsFromAbi<typeof sampleAbi>["demo"]["Position"];
+            direction: "Up" | "Down" | "Left" | "Right";
+        }>();
+        expectTypeOf<Move["outputs"]>().toEqualTypeOf<void>();
+    });
+});


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced ABI tooling to generate a consolidated compiled ABI and optional TypeScript types.
  - Added CLI flags for output location and type generation.
  - Deduplicates ABIs automatically and includes manifest data in outputs.

- Improvements
  - Clearer logging with per-type counts and updated output reporting.
  - Safer file handling with automatic directory creation.

- Documentation
  - Shifted guidance to an ABI-centric workflow with new type utilities and examples.

- Tests
  - Added type-level tests validating model/action extraction and helpers.

- Chores
  - Added changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->