### PR TITLE
feat(grpc): add token contracts informations

### DIFF
--- a/.changeset/open-needles-flow.md
+++ b/.changeset/open-needles-flow.md
@@ -1,0 +1,5 @@
+---
+"@dojoengine/grpc": patch
+---
+
+feat(grpc): add token contract informations

--- a/packages/grpc/proto/types.proto
+++ b/packages/grpc/proto/types.proto
@@ -149,15 +149,6 @@ message Token {
     optional bytes total_supply = 7;
 }
 
-message TokenContract {
-    bytes contract_address = 2;
-    string name = 3;
-    string symbol = 4;
-    uint32 decimals = 5;
-    uint32 count = 6;
-    bytes metadata = 7;
-}
-
 message TokenBalance {
     bytes balance = 1;
     bytes account_address = 2;
@@ -202,14 +193,24 @@ message ControllerQuery {
     Pagination pagination = 3;
 }
 
+// Token attribute filter for filtering tokens by their metadata attributes
+message TokenAttributeFilter {
+    // The name of the trait/attribute to filter by
+    string trait_name = 1;
+    // The value of the trait/attribute to filter by
+    string trait_value = 2;
+}
+
 // A request to retrieve tokens
 message TokenQuery {
     // The list of contract addresses to retrieve tokens for
     repeated bytes contract_addresses = 1;
     // The list of token IDs to retrieve tokens for
     repeated bytes token_ids = 2;
+    // The list of attribute filters to apply
+    repeated TokenAttributeFilter attribute_filters = 3;
     // Pagination
-    Pagination pagination = 3;
+    Pagination pagination = 4;
 }
 
 // A request to retrieve token balances
@@ -219,6 +220,48 @@ message TokenBalanceQuery {
     // The list of token contract addresses to retrieve balances for
     repeated bytes contract_addresses = 2;
     // The list of token IDs to retrieve balances for
+    repeated bytes token_ids = 3;
+    // Pagination
+    Pagination pagination = 4;
+}
+
+// A request to retrieve token contracts
+message TokenContractQuery {
+    // The list of contract addresses to retrieve token contracts for
+    repeated bytes contract_addresses = 1;
+    // The list of contract types to filter by
+    repeated ContractType contract_types = 2;
+    // Pagination
+    Pagination pagination = 3;
+}
+
+// A token transfer record
+message TokenTransfer {
+    // Unique identifier for the transfer (event_id:token_id key)
+    string id = 1;
+    // Contract address of the token
+    bytes contract_address = 2;
+    // Sender address
+    bytes from_address = 3;
+    // Recipient address
+    bytes to_address = 4;
+    // Amount transferred (big-endian bytes)
+    bytes amount = 5;
+    // Token ID when applicable (ERC721/1155); omitted for ERC20
+    optional bytes token_id = 6;
+    // Executed at timestamp (seconds since epoch)
+    uint64 executed_at = 7;
+    // Optional event id that originated this transfer
+    optional string event_id = 8;
+}
+
+// A request to retrieve token transfers
+message TokenTransferQuery {
+    // Filter by any of these account addresses (as sender or recipient)
+    repeated bytes account_addresses = 1;
+    // Filter by token contract addresses
+    repeated bytes contract_addresses = 2;
+    // Filter by token IDs (bytes of numeric id)
     repeated bytes token_ids = 3;
     // Pagination
     Pagination pagination = 4;
@@ -324,4 +367,25 @@ message ContractQuery {
     repeated bytes contract_addresses = 1;
     // The list of contract types to filter by
     repeated ContractType contract_types = 2;
+}
+
+message TokenContract {
+    // The contract address
+    bytes contract_address = 1;
+    // The type of contract
+    ContractType contract_type = 2;
+    // The name of the contract
+    string name = 3;
+    // The symbol of the contract
+    string symbol = 4;
+    // The decimals of the contract
+    uint32 decimals = 5;
+    // The metadata of the contract
+    bytes metadata = 6;
+    // The total supply of the contract
+    optional bytes total_supply = 7;
+    // The traits of the contract (JSON object with trait types and possible values)
+    string traits = 8;
+    // The first token metadata of the contract
+    bytes token_metadata = 9;
 }

--- a/packages/grpc/proto/world.proto
+++ b/packages/grpc/proto/world.proto
@@ -40,6 +40,12 @@ service World {
     // Update token subscription
     rpc UpdateTokensSubscription (UpdateTokenSubscriptionRequest) returns (google.protobuf.Empty);
 
+    // Subscribe to token transfer updates.
+    rpc SubscribeTokenTransfers (SubscribeTokenTransfersRequest) returns (stream SubscribeTokenTransfersResponse);
+
+    // Update token transfer subscription
+    rpc UpdateTokenTransfersSubscription (UpdateTokenTransfersSubscriptionRequest) returns (google.protobuf.Empty);
+
     // Retrieve entities
     rpc RetrieveEventMessages (RetrieveEventMessagesRequest) returns (RetrieveEntitiesResponse);
 
@@ -51,6 +57,9 @@ service World {
 
     // Retrieve tokens
     rpc RetrieveTokens (RetrieveTokensRequest) returns (RetrieveTokensResponse);
+
+    // Retrieve token transfers
+    rpc RetrieveTokenTransfers (RetrieveTokenTransfersRequest) returns (RetrieveTokenTransfersResponse);
 
     // Retrieve token balances
     rpc RetrieveTokenBalances (RetrieveTokenBalancesRequest) returns (RetrieveTokenBalancesResponse);
@@ -67,7 +76,7 @@ service World {
     // Retrieve contracts
     rpc RetrieveContracts (RetrieveContractsRequest) returns (RetrieveContractsResponse);
 
-    // Retrieve tokens contracts
+    // Retrieve token contracts
     rpc RetrieveTokenContracts (RetrieveTokenContractsRequest) returns (RetrieveTokenContractsResponse);
 
     // Publish a torii offchain message
@@ -193,13 +202,13 @@ message RetrieveTransactionsResponse {
 
 // A request to retrieve token contracts
 message RetrieveTokenContractsRequest {
-    types.TokenBalanceQuery query = 1;
+    types.TokenContractQuery query = 1;
 }
 
-// A response containing token balances
+// A response containing token contracts
 message RetrieveTokenContractsResponse {
     string next_cursor = 1;
-    repeated types.TokenContract tokens = 2;
+    repeated types.TokenContract token_contracts = 2;
 }
 
 // A request to subscribe to contract updates.
@@ -293,4 +302,45 @@ message PublishMessageBatchRequest {
 
 message PublishMessageBatchResponse {
     repeated PublishMessageResponse responses = 1;
+}
+
+// A request to subscribe to token transfer updates
+message SubscribeTokenTransfersRequest {
+    // The list of contract addresses to subscribe to
+    repeated bytes contract_addresses = 1;
+    // The list of account addresses to subscribe to (as sender or recipient)
+    repeated bytes account_addresses = 2;
+    // The list of token IDs to subscribe to
+    repeated bytes token_ids = 3;
+}
+
+// A response containing token transfer updates
+message SubscribeTokenTransfersResponse {
+    // The subscription ID
+    uint64 subscription_id = 1;
+    // The token transfer
+    types.TokenTransfer transfer = 2;
+}
+
+// A request to update a token transfer subscription
+message UpdateTokenTransfersSubscriptionRequest {
+    // The subscription ID
+    uint64 subscription_id = 1;
+    // The list of contract addresses to subscribe to
+    repeated bytes contract_addresses = 2;
+    // The list of account addresses to subscribe to (as sender or recipient)
+    repeated bytes account_addresses = 3;
+    // The list of token IDs to subscribe to
+    repeated bytes token_ids = 4;
+}
+
+// A request to retrieve token transfers
+message RetrieveTokenTransfersRequest {
+    types.TokenTransferQuery query = 1;
+}
+
+// A response containing token transfers
+message RetrieveTokenTransfersResponse {
+    string next_cursor = 1;
+    repeated types.TokenTransfer transfers = 2;
 }

--- a/packages/grpc/src/generated/types.ts
+++ b/packages/grpc/src/generated/types.ts
@@ -355,35 +355,6 @@ export interface Token {
     total_supply?: Uint8Array;
 }
 /**
- * @generated from protobuf message types.TokenContract
- */
-export interface TokenContract {
-    /**
-     * @generated from protobuf field: bytes contract_address = 2
-     */
-    contract_address: Uint8Array;
-    /**
-     * @generated from protobuf field: string name = 3
-     */
-    name: string;
-    /**
-     * @generated from protobuf field: string symbol = 4
-     */
-    symbol: string;
-    /**
-     * @generated from protobuf field: uint32 decimals = 5
-     */
-    decimals: number;
-    /**
-     * @generated from protobuf field: uint32 count = 6
-     */
-    count: number;
-    /**
-     * @generated from protobuf field: bytes metadata = 7
-     */
-    metadata: Uint8Array;
-}
-/**
  * @generated from protobuf message types.TokenBalance
  */
 export interface TokenBalance {
@@ -479,6 +450,25 @@ export interface ControllerQuery {
     pagination?: Pagination;
 }
 /**
+ * Token attribute filter for filtering tokens by their metadata attributes
+ *
+ * @generated from protobuf message types.TokenAttributeFilter
+ */
+export interface TokenAttributeFilter {
+    /**
+     * The name of the trait/attribute to filter by
+     *
+     * @generated from protobuf field: string trait_name = 1
+     */
+    trait_name: string;
+    /**
+     * The value of the trait/attribute to filter by
+     *
+     * @generated from protobuf field: string trait_value = 2
+     */
+    trait_value: string;
+}
+/**
  * A request to retrieve tokens
  *
  * @generated from protobuf message types.TokenQuery
@@ -497,9 +487,15 @@ export interface TokenQuery {
      */
     token_ids: Uint8Array[];
     /**
+     * The list of attribute filters to apply
+     *
+     * @generated from protobuf field: repeated types.TokenAttributeFilter attribute_filters = 3
+     */
+    attribute_filters: TokenAttributeFilter[];
+    /**
      * Pagination
      *
-     * @generated from protobuf field: types.Pagination pagination = 3
+     * @generated from protobuf field: types.Pagination pagination = 4
      */
     pagination?: Pagination;
 }
@@ -523,6 +519,117 @@ export interface TokenBalanceQuery {
     contract_addresses: Uint8Array[];
     /**
      * The list of token IDs to retrieve balances for
+     *
+     * @generated from protobuf field: repeated bytes token_ids = 3
+     */
+    token_ids: Uint8Array[];
+    /**
+     * Pagination
+     *
+     * @generated from protobuf field: types.Pagination pagination = 4
+     */
+    pagination?: Pagination;
+}
+/**
+ * A request to retrieve token contracts
+ *
+ * @generated from protobuf message types.TokenContractQuery
+ */
+export interface TokenContractQuery {
+    /**
+     * The list of contract addresses to retrieve token contracts for
+     *
+     * @generated from protobuf field: repeated bytes contract_addresses = 1
+     */
+    contract_addresses: Uint8Array[];
+    /**
+     * The list of contract types to filter by
+     *
+     * @generated from protobuf field: repeated types.ContractType contract_types = 2
+     */
+    contract_types: ContractType[];
+    /**
+     * Pagination
+     *
+     * @generated from protobuf field: types.Pagination pagination = 3
+     */
+    pagination?: Pagination;
+}
+/**
+ * A token transfer record
+ *
+ * @generated from protobuf message types.TokenTransfer
+ */
+export interface TokenTransfer {
+    /**
+     * Unique identifier for the transfer (event_id:token_id key)
+     *
+     * @generated from protobuf field: string id = 1
+     */
+    id: string;
+    /**
+     * Contract address of the token
+     *
+     * @generated from protobuf field: bytes contract_address = 2
+     */
+    contract_address: Uint8Array;
+    /**
+     * Sender address
+     *
+     * @generated from protobuf field: bytes from_address = 3
+     */
+    from_address: Uint8Array;
+    /**
+     * Recipient address
+     *
+     * @generated from protobuf field: bytes to_address = 4
+     */
+    to_address: Uint8Array;
+    /**
+     * Amount transferred (big-endian bytes)
+     *
+     * @generated from protobuf field: bytes amount = 5
+     */
+    amount: Uint8Array;
+    /**
+     * Token ID when applicable (ERC721/1155); omitted for ERC20
+     *
+     * @generated from protobuf field: optional bytes token_id = 6
+     */
+    token_id?: Uint8Array;
+    /**
+     * Executed at timestamp (seconds since epoch)
+     *
+     * @generated from protobuf field: uint64 executed_at = 7
+     */
+    executed_at: bigint;
+    /**
+     * Optional event id that originated this transfer
+     *
+     * @generated from protobuf field: optional string event_id = 8
+     */
+    event_id?: string;
+}
+/**
+ * A request to retrieve token transfers
+ *
+ * @generated from protobuf message types.TokenTransferQuery
+ */
+export interface TokenTransferQuery {
+    /**
+     * Filter by any of these account addresses (as sender or recipient)
+     *
+     * @generated from protobuf field: repeated bytes account_addresses = 1
+     */
+    account_addresses: Uint8Array[];
+    /**
+     * Filter by token contract addresses
+     *
+     * @generated from protobuf field: repeated bytes contract_addresses = 2
+     */
+    contract_addresses: Uint8Array[];
+    /**
+     * Filter by token IDs (bytes of numeric id)
      *
      * @generated from protobuf field: repeated bytes token_ids = 3
      */
@@ -773,6 +880,65 @@ export interface ContractQuery {
      * @generated from protobuf field: repeated types.ContractType contract_types = 2
      */
     contract_types: ContractType[];
+}
+/**
+ * @generated from protobuf message types.TokenContract
+ */
+export interface TokenContract {
+    /**
+     * The contract address
+     *
+     * @generated from protobuf field: bytes contract_address = 1
+     */
+    contract_address: Uint8Array;
+    /**
+     * The type of contract
+     *
+     * @generated from protobuf field: types.ContractType contract_type = 2
+     */
+    contract_type: ContractType;
+    /**
+     * The name of the contract
+     *
+     * @generated from protobuf field: string name = 3
+     */
+    name: string;
+    /**
+     * The symbol of the contract
+     *
+     * @generated from protobuf field: string symbol = 4
+     */
+    symbol: string;
+    /**
+     * The decimals of the contract
+     *
+     * @generated from protobuf field: uint32 decimals = 5
+     */
+    decimals: number;
+    /**
+     * The metadata of the contract
+     *
+     * @generated from protobuf field: bytes metadata = 6
+     */
+    metadata: Uint8Array;
+    /**
+     * The total supply of the contract
+     *
+     * @generated from protobuf field: optional bytes total_supply = 7
+     */
+    total_supply?: Uint8Array;
+    /**
+     * The traits of the contract (JSON object with trait types and possible values)
+     *
+     * @generated from protobuf field: string traits = 8
+     */
+    traits: string;
+    /**
+     * The first token metadata of the contract
+     *
+     * @generated from protobuf field: bytes token_metadata = 9
+     */
+    token_metadata: Uint8Array;
 }
 /**
  * @generated from protobuf enum types.PatternMatching
@@ -1915,93 +2081,6 @@ class Token$Type extends MessageType<Token> {
  */
 export const Token = new Token$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class TokenContract$Type extends MessageType<TokenContract> {
-    constructor() {
-        super("types.TokenContract", [
-            { no: 2, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
-            { no: 3, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 4, name: "symbol", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 5, name: "decimals", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 6, name: "count", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 7, name: "metadata", kind: "scalar", T: 12 /*ScalarType.BYTES*/ }
-        ]);
-    }
-    create(value?: PartialMessage<TokenContract>): TokenContract {
-        const message = globalThis.Object.create((this.messagePrototype!));
-        message.contract_address = new Uint8Array(0);
-        message.name = "";
-        message.symbol = "";
-        message.decimals = 0;
-        message.count = 0;
-        message.metadata = new Uint8Array(0);
-        if (value !== undefined)
-            reflectionMergePartial<TokenContract>(this, message, value);
-        return message;
-    }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenContract): TokenContract {
-        let message = target ?? this.create(), end = reader.pos + length;
-        while (reader.pos < end) {
-            let [fieldNo, wireType] = reader.tag();
-            switch (fieldNo) {
-                case /* bytes contract_address */ 2:
-                    message.contract_address = reader.bytes();
-                    break;
-                case /* string name */ 3:
-                    message.name = reader.string();
-                    break;
-                case /* string symbol */ 4:
-                    message.symbol = reader.string();
-                    break;
-                case /* uint32 decimals */ 5:
-                    message.decimals = reader.uint32();
-                    break;
-                case /* uint32 count */ 6:
-                    message.count = reader.uint32();
-                    break;
-                case /* bytes metadata */ 7:
-                    message.metadata = reader.bytes();
-                    break;
-                default:
-                    let u = options.readUnknownField;
-                    if (u === "throw")
-                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
-                    let d = reader.skip(wireType);
-                    if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
-            }
-        }
-        return message;
-    }
-    internalBinaryWrite(message: TokenContract, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* bytes contract_address = 2; */
-        if (message.contract_address.length)
-            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_address);
-        /* string name = 3; */
-        if (message.name !== "")
-            writer.tag(3, WireType.LengthDelimited).string(message.name);
-        /* string symbol = 4; */
-        if (message.symbol !== "")
-            writer.tag(4, WireType.LengthDelimited).string(message.symbol);
-        /* uint32 decimals = 5; */
-        if (message.decimals !== 0)
-            writer.tag(5, WireType.Varint).uint32(message.decimals);
-        /* uint32 count = 6; */
-        if (message.count !== 0)
-            writer.tag(6, WireType.Varint).uint32(message.count);
-        /* bytes metadata = 7; */
-        if (message.metadata.length)
-            writer.tag(7, WireType.LengthDelimited).bytes(message.metadata);
-        let u = options.writeUnknownFields;
-        if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
-        return writer;
-    }
-}
-/**
- * @generated MessageType for protobuf message types.TokenContract
- */
-export const TokenContract = new TokenContract$Type();
-// @generated message type with reflection information, may provide speed optimized methods
 class TokenBalance$Type extends MessageType<TokenBalance> {
     constructor() {
         super("types.TokenBalance", [
@@ -2323,18 +2402,75 @@ class ControllerQuery$Type extends MessageType<ControllerQuery> {
  */
 export const ControllerQuery = new ControllerQuery$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class TokenAttributeFilter$Type extends MessageType<TokenAttributeFilter> {
+    constructor() {
+        super("types.TokenAttributeFilter", [
+            { no: 1, name: "trait_name", kind: "scalar", localName: "trait_name", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "trait_value", kind: "scalar", localName: "trait_value", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<TokenAttributeFilter>): TokenAttributeFilter {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.trait_name = "";
+        message.trait_value = "";
+        if (value !== undefined)
+            reflectionMergePartial<TokenAttributeFilter>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenAttributeFilter): TokenAttributeFilter {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string trait_name */ 1:
+                    message.trait_name = reader.string();
+                    break;
+                case /* string trait_value */ 2:
+                    message.trait_value = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: TokenAttributeFilter, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string trait_name = 1; */
+        if (message.trait_name !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.trait_name);
+        /* string trait_value = 2; */
+        if (message.trait_value !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.trait_value);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message types.TokenAttributeFilter
+ */
+export const TokenAttributeFilter = new TokenAttributeFilter$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class TokenQuery$Type extends MessageType<TokenQuery> {
     constructor() {
         super("types.TokenQuery", [
             { no: 1, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
             { no: 2, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
-            { no: 3, name: "pagination", kind: "message", T: () => Pagination }
+            { no: 3, name: "attribute_filters", kind: "message", localName: "attribute_filters", repeat: 2 /*RepeatType.UNPACKED*/, T: () => TokenAttributeFilter },
+            { no: 4, name: "pagination", kind: "message", T: () => Pagination }
         ]);
     }
     create(value?: PartialMessage<TokenQuery>): TokenQuery {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.contract_addresses = [];
         message.token_ids = [];
+        message.attribute_filters = [];
         if (value !== undefined)
             reflectionMergePartial<TokenQuery>(this, message, value);
         return message;
@@ -2350,7 +2486,10 @@ class TokenQuery$Type extends MessageType<TokenQuery> {
                 case /* repeated bytes token_ids */ 2:
                     message.token_ids.push(reader.bytes());
                     break;
-                case /* types.Pagination pagination */ 3:
+                case /* repeated types.TokenAttributeFilter attribute_filters */ 3:
+                    message.attribute_filters.push(TokenAttributeFilter.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                case /* types.Pagination pagination */ 4:
                     message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
                     break;
                 default:
@@ -2371,9 +2510,12 @@ class TokenQuery$Type extends MessageType<TokenQuery> {
         /* repeated bytes token_ids = 2; */
         for (let i = 0; i < message.token_ids.length; i++)
             writer.tag(2, WireType.LengthDelimited).bytes(message.token_ids[i]);
-        /* types.Pagination pagination = 3; */
+        /* repeated types.TokenAttributeFilter attribute_filters = 3; */
+        for (let i = 0; i < message.attribute_filters.length; i++)
+            TokenAttributeFilter.internalBinaryWrite(message.attribute_filters[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        /* types.Pagination pagination = 4; */
         if (message.pagination)
-            Pagination.internalBinaryWrite(message.pagination, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2454,6 +2596,247 @@ class TokenBalanceQuery$Type extends MessageType<TokenBalanceQuery> {
  * @generated MessageType for protobuf message types.TokenBalanceQuery
  */
 export const TokenBalanceQuery = new TokenBalanceQuery$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class TokenContractQuery$Type extends MessageType<TokenContractQuery> {
+    constructor() {
+        super("types.TokenContractQuery", [
+            { no: 1, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contract_types", kind: "enum", localName: "contract_types", repeat: 1 /*RepeatType.PACKED*/, T: () => ["types.ContractType", ContractType] },
+            { no: 3, name: "pagination", kind: "message", T: () => Pagination }
+        ]);
+    }
+    create(value?: PartialMessage<TokenContractQuery>): TokenContractQuery {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.contract_addresses = [];
+        message.contract_types = [];
+        if (value !== undefined)
+            reflectionMergePartial<TokenContractQuery>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenContractQuery): TokenContractQuery {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated bytes contract_addresses */ 1:
+                    message.contract_addresses.push(reader.bytes());
+                    break;
+                case /* repeated types.ContractType contract_types */ 2:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.contract_types.push(reader.int32());
+                    else
+                        message.contract_types.push(reader.int32());
+                    break;
+                case /* types.Pagination pagination */ 3:
+                    message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: TokenContractQuery, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated bytes contract_addresses = 1; */
+        for (let i = 0; i < message.contract_addresses.length; i++)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
+        /* repeated types.ContractType contract_types = 2; */
+        if (message.contract_types.length) {
+            writer.tag(2, WireType.LengthDelimited).fork();
+            for (let i = 0; i < message.contract_types.length; i++)
+                writer.int32(message.contract_types[i]);
+            writer.join();
+        }
+        /* types.Pagination pagination = 3; */
+        if (message.pagination)
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message types.TokenContractQuery
+ */
+export const TokenContractQuery = new TokenContractQuery$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class TokenTransfer$Type extends MessageType<TokenTransfer> {
+    constructor() {
+        super("types.TokenTransfer", [
+            { no: 1, name: "id", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "from_address", kind: "scalar", localName: "from_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "to_address", kind: "scalar", localName: "to_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 5, name: "amount", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 6, name: "token_id", kind: "scalar", localName: "token_id", opt: true, T: 12 /*ScalarType.BYTES*/ },
+            { no: 7, name: "executed_at", kind: "scalar", localName: "executed_at", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 8, name: "event_id", kind: "scalar", localName: "event_id", opt: true, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<TokenTransfer>): TokenTransfer {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.id = "";
+        message.contract_address = new Uint8Array(0);
+        message.from_address = new Uint8Array(0);
+        message.to_address = new Uint8Array(0);
+        message.amount = new Uint8Array(0);
+        message.executed_at = 0n;
+        if (value !== undefined)
+            reflectionMergePartial<TokenTransfer>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenTransfer): TokenTransfer {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string id */ 1:
+                    message.id = reader.string();
+                    break;
+                case /* bytes contract_address */ 2:
+                    message.contract_address = reader.bytes();
+                    break;
+                case /* bytes from_address */ 3:
+                    message.from_address = reader.bytes();
+                    break;
+                case /* bytes to_address */ 4:
+                    message.to_address = reader.bytes();
+                    break;
+                case /* bytes amount */ 5:
+                    message.amount = reader.bytes();
+                    break;
+                case /* optional bytes token_id */ 6:
+                    message.token_id = reader.bytes();
+                    break;
+                case /* uint64 executed_at */ 7:
+                    message.executed_at = reader.uint64().toBigInt();
+                    break;
+                case /* optional string event_id */ 8:
+                    message.event_id = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: TokenTransfer, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string id = 1; */
+        if (message.id !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.id);
+        /* bytes contract_address = 2; */
+        if (message.contract_address.length)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_address);
+        /* bytes from_address = 3; */
+        if (message.from_address.length)
+            writer.tag(3, WireType.LengthDelimited).bytes(message.from_address);
+        /* bytes to_address = 4; */
+        if (message.to_address.length)
+            writer.tag(4, WireType.LengthDelimited).bytes(message.to_address);
+        /* bytes amount = 5; */
+        if (message.amount.length)
+            writer.tag(5, WireType.LengthDelimited).bytes(message.amount);
+        /* optional bytes token_id = 6; */
+        if (message.token_id !== undefined)
+            writer.tag(6, WireType.LengthDelimited).bytes(message.token_id);
+        /* uint64 executed_at = 7; */
+        if (message.executed_at !== 0n)
+            writer.tag(7, WireType.Varint).uint64(message.executed_at);
+        /* optional string event_id = 8; */
+        if (message.event_id !== undefined)
+            writer.tag(8, WireType.LengthDelimited).string(message.event_id);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message types.TokenTransfer
+ */
+export const TokenTransfer = new TokenTransfer$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class TokenTransferQuery$Type extends MessageType<TokenTransferQuery> {
+    constructor() {
+        super("types.TokenTransferQuery", [
+            { no: 1, name: "account_addresses", kind: "scalar", localName: "account_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "pagination", kind: "message", T: () => Pagination }
+        ]);
+    }
+    create(value?: PartialMessage<TokenTransferQuery>): TokenTransferQuery {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.account_addresses = [];
+        message.contract_addresses = [];
+        message.token_ids = [];
+        if (value !== undefined)
+            reflectionMergePartial<TokenTransferQuery>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenTransferQuery): TokenTransferQuery {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated bytes account_addresses */ 1:
+                    message.account_addresses.push(reader.bytes());
+                    break;
+                case /* repeated bytes contract_addresses */ 2:
+                    message.contract_addresses.push(reader.bytes());
+                    break;
+                case /* repeated bytes token_ids */ 3:
+                    message.token_ids.push(reader.bytes());
+                    break;
+                case /* types.Pagination pagination */ 4:
+                    message.pagination = Pagination.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: TokenTransferQuery, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated bytes account_addresses = 1; */
+        for (let i = 0; i < message.account_addresses.length; i++)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.account_addresses[i]);
+        /* repeated bytes contract_addresses = 2; */
+        for (let i = 0; i < message.contract_addresses.length; i++)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
+        /* repeated bytes token_ids = 3; */
+        for (let i = 0; i < message.token_ids.length; i++)
+            writer.tag(3, WireType.LengthDelimited).bytes(message.token_ids[i]);
+        /* types.Pagination pagination = 4; */
+        if (message.pagination)
+            Pagination.internalBinaryWrite(message.pagination, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message types.TokenTransferQuery
+ */
+export const TokenTransferQuery = new TokenTransferQuery$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class TransactionCall$Type extends MessageType<TransactionCall> {
     constructor() {
@@ -2968,3 +3351,113 @@ class ContractQuery$Type extends MessageType<ContractQuery> {
  * @generated MessageType for protobuf message types.ContractQuery
  */
 export const ContractQuery = new ContractQuery$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class TokenContract$Type extends MessageType<TokenContract> {
+    constructor() {
+        super("types.TokenContract", [
+            { no: 1, name: "contract_address", kind: "scalar", localName: "contract_address", T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "contract_type", kind: "enum", localName: "contract_type", T: () => ["types.ContractType", ContractType] },
+            { no: 3, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 4, name: "symbol", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 5, name: "decimals", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
+            { no: 6, name: "metadata", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
+            { no: 7, name: "total_supply", kind: "scalar", localName: "total_supply", opt: true, T: 12 /*ScalarType.BYTES*/ },
+            { no: 8, name: "traits", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "token_metadata", kind: "scalar", localName: "token_metadata", T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+    create(value?: PartialMessage<TokenContract>): TokenContract {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.contract_address = new Uint8Array(0);
+        message.contract_type = 0;
+        message.name = "";
+        message.symbol = "";
+        message.decimals = 0;
+        message.metadata = new Uint8Array(0);
+        message.traits = "";
+        message.token_metadata = new Uint8Array(0);
+        if (value !== undefined)
+            reflectionMergePartial<TokenContract>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TokenContract): TokenContract {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* bytes contract_address */ 1:
+                    message.contract_address = reader.bytes();
+                    break;
+                case /* types.ContractType contract_type */ 2:
+                    message.contract_type = reader.int32();
+                    break;
+                case /* string name */ 3:
+                    message.name = reader.string();
+                    break;
+                case /* string symbol */ 4:
+                    message.symbol = reader.string();
+                    break;
+                case /* uint32 decimals */ 5:
+                    message.decimals = reader.uint32();
+                    break;
+                case /* bytes metadata */ 6:
+                    message.metadata = reader.bytes();
+                    break;
+                case /* optional bytes total_supply */ 7:
+                    message.total_supply = reader.bytes();
+                    break;
+                case /* string traits */ 8:
+                    message.traits = reader.string();
+                    break;
+                case /* bytes token_metadata */ 9:
+                    message.token_metadata = reader.bytes();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: TokenContract, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* bytes contract_address = 1; */
+        if (message.contract_address.length)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_address);
+        /* types.ContractType contract_type = 2; */
+        if (message.contract_type !== 0)
+            writer.tag(2, WireType.Varint).int32(message.contract_type);
+        /* string name = 3; */
+        if (message.name !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.name);
+        /* string symbol = 4; */
+        if (message.symbol !== "")
+            writer.tag(4, WireType.LengthDelimited).string(message.symbol);
+        /* uint32 decimals = 5; */
+        if (message.decimals !== 0)
+            writer.tag(5, WireType.Varint).uint32(message.decimals);
+        /* bytes metadata = 6; */
+        if (message.metadata.length)
+            writer.tag(6, WireType.LengthDelimited).bytes(message.metadata);
+        /* optional bytes total_supply = 7; */
+        if (message.total_supply !== undefined)
+            writer.tag(7, WireType.LengthDelimited).bytes(message.total_supply);
+        /* string traits = 8; */
+        if (message.traits !== "")
+            writer.tag(8, WireType.LengthDelimited).string(message.traits);
+        /* bytes token_metadata = 9; */
+        if (message.token_metadata.length)
+            writer.tag(9, WireType.LengthDelimited).bytes(message.token_metadata);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message types.TokenContract
+ */
+export const TokenContract = new TokenContract$Type();

--- a/packages/grpc/src/generated/world.client.ts
+++ b/packages/grpc/src/generated/world.client.ts
@@ -20,6 +20,8 @@ import type { RetrieveTransactionsResponse } from "./world";
 import type { RetrieveTransactionsRequest } from "./world";
 import type { RetrieveTokenBalancesResponse } from "./world";
 import type { RetrieveTokenBalancesRequest } from "./world";
+import type { RetrieveTokenTransfersResponse } from "./world";
+import type { RetrieveTokenTransfersRequest } from "./world";
 import type { RetrieveTokensResponse } from "./world";
 import type { RetrieveTokensRequest } from "./world";
 import type { SubscribeEventsResponse } from "./world";
@@ -27,6 +29,9 @@ import type { SubscribeEventsRequest } from "./world";
 import type { RetrieveEventsResponse } from "./world";
 import type { RetrieveEventsRequest } from "./world";
 import type { RetrieveEventMessagesRequest } from "./world";
+import type { UpdateTokenTransfersSubscriptionRequest } from "./world";
+import type { SubscribeTokenTransfersResponse } from "./world";
+import type { SubscribeTokenTransfersRequest } from "./world";
 import type { UpdateTokenSubscriptionRequest } from "./world";
 import type { SubscribeTokensResponse } from "./world";
 import type { SubscribeTokensRequest } from "./world";
@@ -122,6 +127,18 @@ export interface IWorldClient {
      */
     updateTokensSubscription(input: UpdateTokenSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateTokenSubscriptionRequest, Empty>;
     /**
+     * Subscribe to token transfer updates.
+     *
+     * @generated from protobuf rpc: SubscribeTokenTransfers
+     */
+    subscribeTokenTransfers(input: SubscribeTokenTransfersRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTokenTransfersRequest, SubscribeTokenTransfersResponse>;
+    /**
+     * Update token transfer subscription
+     *
+     * @generated from protobuf rpc: UpdateTokenTransfersSubscription
+     */
+    updateTokenTransfersSubscription(input: UpdateTokenTransfersSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateTokenTransfersSubscriptionRequest, Empty>;
+    /**
      * Retrieve entities
      *
      * @generated from protobuf rpc: RetrieveEventMessages
@@ -145,6 +162,12 @@ export interface IWorldClient {
      * @generated from protobuf rpc: RetrieveTokens
      */
     retrieveTokens(input: RetrieveTokensRequest, options?: RpcOptions): UnaryCall<RetrieveTokensRequest, RetrieveTokensResponse>;
+    /**
+     * Retrieve token transfers
+     *
+     * @generated from protobuf rpc: RetrieveTokenTransfers
+     */
+    retrieveTokenTransfers(input: RetrieveTokenTransfersRequest, options?: RpcOptions): UnaryCall<RetrieveTokenTransfersRequest, RetrieveTokenTransfersResponse>;
     /**
      * Retrieve token balances
      *
@@ -176,7 +199,7 @@ export interface IWorldClient {
      */
     retrieveContracts(input: RetrieveContractsRequest, options?: RpcOptions): UnaryCall<RetrieveContractsRequest, RetrieveContractsResponse>;
     /**
-     * Retrieve tokens contracts
+     * Retrieve token contracts
      *
      * @generated from protobuf rpc: RetrieveTokenContracts
      */
@@ -305,12 +328,30 @@ export class WorldClient implements IWorldClient, ServiceInfo {
         return stackIntercept<UpdateTokenSubscriptionRequest, Empty>("unary", this._transport, method, opt, input);
     }
     /**
+     * Subscribe to token transfer updates.
+     *
+     * @generated from protobuf rpc: SubscribeTokenTransfers
+     */
+    subscribeTokenTransfers(input: SubscribeTokenTransfersRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTokenTransfersRequest, SubscribeTokenTransfersResponse> {
+        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        return stackIntercept<SubscribeTokenTransfersRequest, SubscribeTokenTransfersResponse>("serverStreaming", this._transport, method, opt, input);
+    }
+    /**
+     * Update token transfer subscription
+     *
+     * @generated from protobuf rpc: UpdateTokenTransfersSubscription
+     */
+    updateTokenTransfersSubscription(input: UpdateTokenTransfersSubscriptionRequest, options?: RpcOptions): UnaryCall<UpdateTokenTransfersSubscriptionRequest, Empty> {
+        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        return stackIntercept<UpdateTokenTransfersSubscriptionRequest, Empty>("unary", this._transport, method, opt, input);
+    }
+    /**
      * Retrieve entities
      *
      * @generated from protobuf rpc: RetrieveEventMessages
      */
     retrieveEventMessages(input: RetrieveEventMessagesRequest, options?: RpcOptions): UnaryCall<RetrieveEventMessagesRequest, RetrieveEntitiesResponse> {
-        const method = this.methods[11], opt = this._transport.mergeOptions(options);
+        const method = this.methods[13], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveEventMessagesRequest, RetrieveEntitiesResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -319,7 +360,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: RetrieveEvents
      */
     retrieveEvents(input: RetrieveEventsRequest, options?: RpcOptions): UnaryCall<RetrieveEventsRequest, RetrieveEventsResponse> {
-        const method = this.methods[12], opt = this._transport.mergeOptions(options);
+        const method = this.methods[14], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveEventsRequest, RetrieveEventsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -328,7 +369,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: SubscribeEvents
      */
     subscribeEvents(input: SubscribeEventsRequest, options?: RpcOptions): ServerStreamingCall<SubscribeEventsRequest, SubscribeEventsResponse> {
-        const method = this.methods[13], opt = this._transport.mergeOptions(options);
+        const method = this.methods[15], opt = this._transport.mergeOptions(options);
         return stackIntercept<SubscribeEventsRequest, SubscribeEventsResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
@@ -337,8 +378,17 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: RetrieveTokens
      */
     retrieveTokens(input: RetrieveTokensRequest, options?: RpcOptions): UnaryCall<RetrieveTokensRequest, RetrieveTokensResponse> {
-        const method = this.methods[14], opt = this._transport.mergeOptions(options);
+        const method = this.methods[16], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveTokensRequest, RetrieveTokensResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
+     * Retrieve token transfers
+     *
+     * @generated from protobuf rpc: RetrieveTokenTransfers
+     */
+    retrieveTokenTransfers(input: RetrieveTokenTransfersRequest, options?: RpcOptions): UnaryCall<RetrieveTokenTransfersRequest, RetrieveTokenTransfersResponse> {
+        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        return stackIntercept<RetrieveTokenTransfersRequest, RetrieveTokenTransfersResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * Retrieve token balances
@@ -346,7 +396,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: RetrieveTokenBalances
      */
     retrieveTokenBalances(input: RetrieveTokenBalancesRequest, options?: RpcOptions): UnaryCall<RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse> {
-        const method = this.methods[15], opt = this._transport.mergeOptions(options);
+        const method = this.methods[18], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -355,7 +405,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: RetrieveTransactions
      */
     retrieveTransactions(input: RetrieveTransactionsRequest, options?: RpcOptions): UnaryCall<RetrieveTransactionsRequest, RetrieveTransactionsResponse> {
-        const method = this.methods[16], opt = this._transport.mergeOptions(options);
+        const method = this.methods[19], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveTransactionsRequest, RetrieveTransactionsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -364,7 +414,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: SubscribeTransactions
      */
     subscribeTransactions(input: SubscribeTransactionsRequest, options?: RpcOptions): ServerStreamingCall<SubscribeTransactionsRequest, SubscribeTransactionsResponse> {
-        const method = this.methods[17], opt = this._transport.mergeOptions(options);
+        const method = this.methods[20], opt = this._transport.mergeOptions(options);
         return stackIntercept<SubscribeTransactionsRequest, SubscribeTransactionsResponse>("serverStreaming", this._transport, method, opt, input);
     }
     /**
@@ -373,7 +423,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: RetrieveControllers
      */
     retrieveControllers(input: RetrieveControllersRequest, options?: RpcOptions): UnaryCall<RetrieveControllersRequest, RetrieveControllersResponse> {
-        const method = this.methods[18], opt = this._transport.mergeOptions(options);
+        const method = this.methods[21], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveControllersRequest, RetrieveControllersResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -382,16 +432,16 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: RetrieveContracts
      */
     retrieveContracts(input: RetrieveContractsRequest, options?: RpcOptions): UnaryCall<RetrieveContractsRequest, RetrieveContractsResponse> {
-        const method = this.methods[19], opt = this._transport.mergeOptions(options);
+        const method = this.methods[22], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveContractsRequest, RetrieveContractsResponse>("unary", this._transport, method, opt, input);
     }
     /**
-     * Retrieve tokens contracts
+     * Retrieve token contracts
      *
      * @generated from protobuf rpc: RetrieveTokenContracts
      */
     retrieveTokenContracts(input: RetrieveTokenContractsRequest, options?: RpcOptions): UnaryCall<RetrieveTokenContractsRequest, RetrieveTokenContractsResponse> {
-        const method = this.methods[20], opt = this._transport.mergeOptions(options);
+        const method = this.methods[23], opt = this._transport.mergeOptions(options);
         return stackIntercept<RetrieveTokenContractsRequest, RetrieveTokenContractsResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -400,7 +450,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: PublishMessage
      */
     publishMessage(input: PublishMessageRequest, options?: RpcOptions): UnaryCall<PublishMessageRequest, PublishMessageResponse> {
-        const method = this.methods[21], opt = this._transport.mergeOptions(options);
+        const method = this.methods[24], opt = this._transport.mergeOptions(options);
         return stackIntercept<PublishMessageRequest, PublishMessageResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -409,7 +459,7 @@ export class WorldClient implements IWorldClient, ServiceInfo {
      * @generated from protobuf rpc: PublishMessageBatch
      */
     publishMessageBatch(input: PublishMessageBatchRequest, options?: RpcOptions): UnaryCall<PublishMessageBatchRequest, PublishMessageBatchResponse> {
-        const method = this.methods[22], opt = this._transport.mergeOptions(options);
+        const method = this.methods[25], opt = this._transport.mergeOptions(options);
         return stackIntercept<PublishMessageBatchRequest, PublishMessageBatchResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/packages/grpc/src/generated/world.ts
+++ b/packages/grpc/src/generated/world.ts
@@ -12,6 +12,8 @@ import { UnknownFieldHandler } from "@protobuf-ts/runtime";
 import type { PartialMessage } from "@protobuf-ts/runtime";
 import { reflectionMergePartial } from "@protobuf-ts/runtime";
 import { MessageType } from "@protobuf-ts/runtime";
+import { TokenTransferQuery } from "./types";
+import { TokenTransfer } from "./types";
 import { KeysClause } from "./types";
 import { Event } from "./types";
 import { EventQuery } from "./types";
@@ -20,6 +22,7 @@ import { Entity } from "./types";
 import { Clause } from "./types";
 import { World as World$ } from "./types";
 import { TokenContract } from "./types";
+import { TokenContractQuery } from "./types";
 import { TransactionQuery } from "./types";
 import { TokenBalanceQuery } from "./types";
 import { Token } from "./types";
@@ -312,12 +315,12 @@ export interface RetrieveTransactionsResponse {
  */
 export interface RetrieveTokenContractsRequest {
     /**
-     * @generated from protobuf field: types.TokenBalanceQuery query = 1
+     * @generated from protobuf field: types.TokenContractQuery query = 1
      */
-    query?: TokenBalanceQuery;
+    query?: TokenContractQuery;
 }
 /**
- * A response containing token balances
+ * A response containing token contracts
  *
  * @generated from protobuf message world.RetrieveTokenContractsResponse
  */
@@ -327,9 +330,9 @@ export interface RetrieveTokenContractsResponse {
      */
     next_cursor: string;
     /**
-     * @generated from protobuf field: repeated types.TokenContract tokens = 2
+     * @generated from protobuf field: repeated types.TokenContract token_contracts = 2
      */
-    tokens: TokenContract[];
+    token_contracts: TokenContract[];
 }
 /**
  * A request to subscribe to contract updates.
@@ -544,6 +547,107 @@ export interface PublishMessageBatchResponse {
      * @generated from protobuf field: repeated world.PublishMessageResponse responses = 1
      */
     responses: PublishMessageResponse[];
+}
+/**
+ * A request to subscribe to token transfer updates
+ *
+ * @generated from protobuf message world.SubscribeTokenTransfersRequest
+ */
+export interface SubscribeTokenTransfersRequest {
+    /**
+     * The list of contract addresses to subscribe to
+     *
+     * @generated from protobuf field: repeated bytes contract_addresses = 1
+     */
+    contract_addresses: Uint8Array[];
+    /**
+     * The list of account addresses to subscribe to (as sender or recipient)
+     *
+     * @generated from protobuf field: repeated bytes account_addresses = 2
+     */
+    account_addresses: Uint8Array[];
+    /**
+     * The list of token IDs to subscribe to
+     *
+     * @generated from protobuf field: repeated bytes token_ids = 3
+     */
+    token_ids: Uint8Array[];
+}
+/**
+ * A response containing token transfer updates
+ *
+ * @generated from protobuf message world.SubscribeTokenTransfersResponse
+ */
+export interface SubscribeTokenTransfersResponse {
+    /**
+     * The subscription ID
+     *
+     * @generated from protobuf field: uint64 subscription_id = 1
+     */
+    subscription_id: bigint;
+    /**
+     * The token transfer
+     *
+     * @generated from protobuf field: types.TokenTransfer transfer = 2
+     */
+    transfer?: TokenTransfer;
+}
+/**
+ * A request to update a token transfer subscription
+ *
+ * @generated from protobuf message world.UpdateTokenTransfersSubscriptionRequest
+ */
+export interface UpdateTokenTransfersSubscriptionRequest {
+    /**
+     * The subscription ID
+     *
+     * @generated from protobuf field: uint64 subscription_id = 1
+     */
+    subscription_id: bigint;
+    /**
+     * The list of contract addresses to subscribe to
+     *
+     * @generated from protobuf field: repeated bytes contract_addresses = 2
+     */
+    contract_addresses: Uint8Array[];
+    /**
+     * The list of account addresses to subscribe to (as sender or recipient)
+     *
+     * @generated from protobuf field: repeated bytes account_addresses = 3
+     */
+    account_addresses: Uint8Array[];
+    /**
+     * The list of token IDs to subscribe to
+     *
+     * @generated from protobuf field: repeated bytes token_ids = 4
+     */
+    token_ids: Uint8Array[];
+}
+/**
+ * A request to retrieve token transfers
+ *
+ * @generated from protobuf message world.RetrieveTokenTransfersRequest
+ */
+export interface RetrieveTokenTransfersRequest {
+    /**
+     * @generated from protobuf field: types.TokenTransferQuery query = 1
+     */
+    query?: TokenTransferQuery;
+}
+/**
+ * A response containing token transfers
+ *
+ * @generated from protobuf message world.RetrieveTokenTransfersResponse
+ */
+export interface RetrieveTokenTransfersResponse {
+    /**
+     * @generated from protobuf field: string next_cursor = 1
+     */
+    next_cursor: string;
+    /**
+     * @generated from protobuf field: repeated types.TokenTransfer transfers = 2
+     */
+    transfers: TokenTransfer[];
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class SubscribeTransactionsRequest$Type extends MessageType<SubscribeTransactionsRequest> {
@@ -1498,7 +1602,7 @@ export const RetrieveTransactionsResponse = new RetrieveTransactionsResponse$Typ
 class RetrieveTokenContractsRequest$Type extends MessageType<RetrieveTokenContractsRequest> {
     constructor() {
         super("world.RetrieveTokenContractsRequest", [
-            { no: 1, name: "query", kind: "message", T: () => TokenBalanceQuery }
+            { no: 1, name: "query", kind: "message", T: () => TokenContractQuery }
         ]);
     }
     create(value?: PartialMessage<RetrieveTokenContractsRequest>): RetrieveTokenContractsRequest {
@@ -1512,8 +1616,8 @@ class RetrieveTokenContractsRequest$Type extends MessageType<RetrieveTokenContra
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* types.TokenBalanceQuery query */ 1:
-                    message.query = TokenBalanceQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
+                case /* types.TokenContractQuery query */ 1:
+                    message.query = TokenContractQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1527,9 +1631,9 @@ class RetrieveTokenContractsRequest$Type extends MessageType<RetrieveTokenContra
         return message;
     }
     internalBinaryWrite(message: RetrieveTokenContractsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* types.TokenBalanceQuery query = 1; */
+        /* types.TokenContractQuery query = 1; */
         if (message.query)
-            TokenBalanceQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+            TokenContractQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -1545,13 +1649,13 @@ class RetrieveTokenContractsResponse$Type extends MessageType<RetrieveTokenContr
     constructor() {
         super("world.RetrieveTokenContractsResponse", [
             { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "tokens", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => TokenContract }
+            { no: 2, name: "token_contracts", kind: "message", localName: "token_contracts", repeat: 2 /*RepeatType.UNPACKED*/, T: () => TokenContract }
         ]);
     }
     create(value?: PartialMessage<RetrieveTokenContractsResponse>): RetrieveTokenContractsResponse {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.next_cursor = "";
-        message.tokens = [];
+        message.token_contracts = [];
         if (value !== undefined)
             reflectionMergePartial<RetrieveTokenContractsResponse>(this, message, value);
         return message;
@@ -1564,8 +1668,8 @@ class RetrieveTokenContractsResponse$Type extends MessageType<RetrieveTokenContr
                 case /* string next_cursor */ 1:
                     message.next_cursor = reader.string();
                     break;
-                case /* repeated types.TokenContract tokens */ 2:
-                    message.tokens.push(TokenContract.internalBinaryRead(reader, reader.uint32(), options));
+                case /* repeated types.TokenContract token_contracts */ 2:
+                    message.token_contracts.push(TokenContract.internalBinaryRead(reader, reader.uint32(), options));
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1582,9 +1686,9 @@ class RetrieveTokenContractsResponse$Type extends MessageType<RetrieveTokenContr
         /* string next_cursor = 1; */
         if (message.next_cursor !== "")
             writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
-        /* repeated types.TokenContract tokens = 2; */
-        for (let i = 0; i < message.tokens.length; i++)
-            TokenContract.internalBinaryWrite(message.tokens[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* repeated types.TokenContract token_contracts = 2; */
+        for (let i = 0; i < message.token_contracts.length; i++)
+            TokenContract.internalBinaryWrite(message.token_contracts[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2562,6 +2666,295 @@ class PublishMessageBatchResponse$Type extends MessageType<PublishMessageBatchRe
  * @generated MessageType for protobuf message world.PublishMessageBatchResponse
  */
 export const PublishMessageBatchResponse = new PublishMessageBatchResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class SubscribeTokenTransfersRequest$Type extends MessageType<SubscribeTokenTransfersRequest> {
+    constructor() {
+        super("world.SubscribeTokenTransfersRequest", [
+            { no: 1, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 2, name: "account_addresses", kind: "scalar", localName: "account_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+    create(value?: PartialMessage<SubscribeTokenTransfersRequest>): SubscribeTokenTransfersRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.contract_addresses = [];
+        message.account_addresses = [];
+        message.token_ids = [];
+        if (value !== undefined)
+            reflectionMergePartial<SubscribeTokenTransfersRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeTokenTransfersRequest): SubscribeTokenTransfersRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* repeated bytes contract_addresses */ 1:
+                    message.contract_addresses.push(reader.bytes());
+                    break;
+                case /* repeated bytes account_addresses */ 2:
+                    message.account_addresses.push(reader.bytes());
+                    break;
+                case /* repeated bytes token_ids */ 3:
+                    message.token_ids.push(reader.bytes());
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: SubscribeTokenTransfersRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated bytes contract_addresses = 1; */
+        for (let i = 0; i < message.contract_addresses.length; i++)
+            writer.tag(1, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
+        /* repeated bytes account_addresses = 2; */
+        for (let i = 0; i < message.account_addresses.length; i++)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.account_addresses[i]);
+        /* repeated bytes token_ids = 3; */
+        for (let i = 0; i < message.token_ids.length; i++)
+            writer.tag(3, WireType.LengthDelimited).bytes(message.token_ids[i]);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message world.SubscribeTokenTransfersRequest
+ */
+export const SubscribeTokenTransfersRequest = new SubscribeTokenTransfersRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class SubscribeTokenTransfersResponse$Type extends MessageType<SubscribeTokenTransfersResponse> {
+    constructor() {
+        super("world.SubscribeTokenTransfersResponse", [
+            { no: 1, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "transfer", kind: "message", T: () => TokenTransfer }
+        ]);
+    }
+    create(value?: PartialMessage<SubscribeTokenTransfersResponse>): SubscribeTokenTransfersResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.subscription_id = 0n;
+        if (value !== undefined)
+            reflectionMergePartial<SubscribeTokenTransfersResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: SubscribeTokenTransfersResponse): SubscribeTokenTransfersResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint64 subscription_id */ 1:
+                    message.subscription_id = reader.uint64().toBigInt();
+                    break;
+                case /* types.TokenTransfer transfer */ 2:
+                    message.transfer = TokenTransfer.internalBinaryRead(reader, reader.uint32(), options, message.transfer);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: SubscribeTokenTransfersResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint64 subscription_id = 1; */
+        if (message.subscription_id !== 0n)
+            writer.tag(1, WireType.Varint).uint64(message.subscription_id);
+        /* types.TokenTransfer transfer = 2; */
+        if (message.transfer)
+            TokenTransfer.internalBinaryWrite(message.transfer, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message world.SubscribeTokenTransfersResponse
+ */
+export const SubscribeTokenTransfersResponse = new SubscribeTokenTransfersResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class UpdateTokenTransfersSubscriptionRequest$Type extends MessageType<UpdateTokenTransfersSubscriptionRequest> {
+    constructor() {
+        super("world.UpdateTokenTransfersSubscriptionRequest", [
+            { no: 1, name: "subscription_id", kind: "scalar", localName: "subscription_id", T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 2, name: "contract_addresses", kind: "scalar", localName: "contract_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 3, name: "account_addresses", kind: "scalar", localName: "account_addresses", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ },
+            { no: 4, name: "token_ids", kind: "scalar", localName: "token_ids", repeat: 2 /*RepeatType.UNPACKED*/, T: 12 /*ScalarType.BYTES*/ }
+        ]);
+    }
+    create(value?: PartialMessage<UpdateTokenTransfersSubscriptionRequest>): UpdateTokenTransfersSubscriptionRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.subscription_id = 0n;
+        message.contract_addresses = [];
+        message.account_addresses = [];
+        message.token_ids = [];
+        if (value !== undefined)
+            reflectionMergePartial<UpdateTokenTransfersSubscriptionRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateTokenTransfersSubscriptionRequest): UpdateTokenTransfersSubscriptionRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* uint64 subscription_id */ 1:
+                    message.subscription_id = reader.uint64().toBigInt();
+                    break;
+                case /* repeated bytes contract_addresses */ 2:
+                    message.contract_addresses.push(reader.bytes());
+                    break;
+                case /* repeated bytes account_addresses */ 3:
+                    message.account_addresses.push(reader.bytes());
+                    break;
+                case /* repeated bytes token_ids */ 4:
+                    message.token_ids.push(reader.bytes());
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: UpdateTokenTransfersSubscriptionRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* uint64 subscription_id = 1; */
+        if (message.subscription_id !== 0n)
+            writer.tag(1, WireType.Varint).uint64(message.subscription_id);
+        /* repeated bytes contract_addresses = 2; */
+        for (let i = 0; i < message.contract_addresses.length; i++)
+            writer.tag(2, WireType.LengthDelimited).bytes(message.contract_addresses[i]);
+        /* repeated bytes account_addresses = 3; */
+        for (let i = 0; i < message.account_addresses.length; i++)
+            writer.tag(3, WireType.LengthDelimited).bytes(message.account_addresses[i]);
+        /* repeated bytes token_ids = 4; */
+        for (let i = 0; i < message.token_ids.length; i++)
+            writer.tag(4, WireType.LengthDelimited).bytes(message.token_ids[i]);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message world.UpdateTokenTransfersSubscriptionRequest
+ */
+export const UpdateTokenTransfersSubscriptionRequest = new UpdateTokenTransfersSubscriptionRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class RetrieveTokenTransfersRequest$Type extends MessageType<RetrieveTokenTransfersRequest> {
+    constructor() {
+        super("world.RetrieveTokenTransfersRequest", [
+            { no: 1, name: "query", kind: "message", T: () => TokenTransferQuery }
+        ]);
+    }
+    create(value?: PartialMessage<RetrieveTokenTransfersRequest>): RetrieveTokenTransfersRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<RetrieveTokenTransfersRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTokenTransfersRequest): RetrieveTokenTransfersRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* types.TokenTransferQuery query */ 1:
+                    message.query = TokenTransferQuery.internalBinaryRead(reader, reader.uint32(), options, message.query);
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: RetrieveTokenTransfersRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* types.TokenTransferQuery query = 1; */
+        if (message.query)
+            TokenTransferQuery.internalBinaryWrite(message.query, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message world.RetrieveTokenTransfersRequest
+ */
+export const RetrieveTokenTransfersRequest = new RetrieveTokenTransfersRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class RetrieveTokenTransfersResponse$Type extends MessageType<RetrieveTokenTransfersResponse> {
+    constructor() {
+        super("world.RetrieveTokenTransfersResponse", [
+            { no: 1, name: "next_cursor", kind: "scalar", localName: "next_cursor", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "transfers", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => TokenTransfer }
+        ]);
+    }
+    create(value?: PartialMessage<RetrieveTokenTransfersResponse>): RetrieveTokenTransfersResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.next_cursor = "";
+        message.transfers = [];
+        if (value !== undefined)
+            reflectionMergePartial<RetrieveTokenTransfersResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: RetrieveTokenTransfersResponse): RetrieveTokenTransfersResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string next_cursor */ 1:
+                    message.next_cursor = reader.string();
+                    break;
+                case /* repeated types.TokenTransfer transfers */ 2:
+                    message.transfers.push(TokenTransfer.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: RetrieveTokenTransfersResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string next_cursor = 1; */
+        if (message.next_cursor !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.next_cursor);
+        /* repeated types.TokenTransfer transfers = 2; */
+        for (let i = 0; i < message.transfers.length; i++)
+            TokenTransfer.internalBinaryWrite(message.transfers[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message world.RetrieveTokenTransfersResponse
+ */
+export const RetrieveTokenTransfersResponse = new RetrieveTokenTransfersResponse$Type();
 /**
  * @generated ServiceType for protobuf service world.World
  */
@@ -2577,10 +2970,13 @@ export const World = new ServiceType("world.World", [
     { name: "UpdateTokenBalancesSubscription", options: {}, I: UpdateTokenBalancesSubscriptionRequest, O: Empty },
     { name: "SubscribeTokens", serverStreaming: true, options: {}, I: SubscribeTokensRequest, O: SubscribeTokensResponse },
     { name: "UpdateTokensSubscription", options: {}, I: UpdateTokenSubscriptionRequest, O: Empty },
+    { name: "SubscribeTokenTransfers", serverStreaming: true, options: {}, I: SubscribeTokenTransfersRequest, O: SubscribeTokenTransfersResponse },
+    { name: "UpdateTokenTransfersSubscription", options: {}, I: UpdateTokenTransfersSubscriptionRequest, O: Empty },
     { name: "RetrieveEventMessages", options: {}, I: RetrieveEventMessagesRequest, O: RetrieveEntitiesResponse },
     { name: "RetrieveEvents", options: {}, I: RetrieveEventsRequest, O: RetrieveEventsResponse },
     { name: "SubscribeEvents", serverStreaming: true, options: {}, I: SubscribeEventsRequest, O: SubscribeEventsResponse },
     { name: "RetrieveTokens", options: {}, I: RetrieveTokensRequest, O: RetrieveTokensResponse },
+    { name: "RetrieveTokenTransfers", options: {}, I: RetrieveTokenTransfersRequest, O: RetrieveTokenTransfersResponse },
     { name: "RetrieveTokenBalances", options: {}, I: RetrieveTokenBalancesRequest, O: RetrieveTokenBalancesResponse },
     { name: "RetrieveTransactions", options: {}, I: RetrieveTransactionsRequest, O: RetrieveTransactionsResponse },
     { name: "SubscribeTransactions", serverStreaming: true, options: {}, I: SubscribeTransactionsRequest, O: SubscribeTransactionsResponse },

--- a/packages/grpc/src/mappings/query.ts
+++ b/packages/grpc/src/mappings/query.ts
@@ -11,9 +11,11 @@ import type {
     ControllerQuery as ToriiControllerQuery,
     TokenQuery as ToriiTokenQuery,
     TokenBalanceQuery as ToriiTokenBalanceQuery,
+    TokenContractQuery as ToriiTokenContractQuery,
     TransactionQuery as ToriiTransactionQuery,
     TransactionFilter as ToriiTransactionFilter,
     KeysClause as ToriiKeysClause,
+    ContractType,
 } from "@dojoengine/torii-wasm";
 
 import type {
@@ -29,6 +31,7 @@ import type {
     ControllerQuery as GrpcControllerQuery,
     TokenQuery as GrpcTokenQuery,
     TokenBalanceQuery as GrpcTokenBalanceQuery,
+    TokenContractQuery as GrpcTokenContractQuery,
     TransactionQuery as GrpcTransactionQuery,
     TransactionFilter as GrpcTransactionFilter,
     EventQuery as GrpcEventQuery,
@@ -264,6 +267,16 @@ export function mapTokenBalanceQuery(
     };
 }
 
+export function mapTokenContractQuery(
+    query: ToriiTokenContractQuery
+): GrpcTokenContractQuery {
+    return {
+        contract_addresses: query.contract_addresses.map(hexToBuffer),
+        contract_types: query.contract_types as ContractType[],
+        pagination: mapPagination(query.pagination),
+    };
+}
+
 export function mapTransactionFilter(
     filter: ToriiTransactionFilter
 ): GrpcTransactionFilter {
@@ -320,10 +333,10 @@ export function createRetrieveTokenBalancesRequest(
 }
 
 export function createRetrieveTokenContractsRequest(
-    query: ToriiTokenBalanceQuery
+    query: ToriiTokenContractQuery
 ): RetrieveTokenContractsRequest {
     return {
-        query: mapTokenBalanceQuery(query),
+        query: mapTokenContractQuery(query),
     };
 }
 

--- a/packages/grpc/src/mappings/types.ts
+++ b/packages/grpc/src/mappings/types.ts
@@ -198,14 +198,16 @@ export function mapTokenBalancesResponse(
 
 export function mapTokenContract(
     collection: GrpcTokenContract
-): ToriiTokenContract {
+): GrpcTokenContract {
     return {
         contract_address: bufferToHex(collection.contract_address),
         name: collection.name,
         symbol: collection.symbol,
         decimals: collection.decimals,
-        count: collection.count,
+        total_supply: bufferToHex(collection.total_supply),
         metadata: parseJsonMetadata(collection.metadata),
+        traits: JSON.parse(collection.traits),
+        token_metadata: parseJsonMetadata(collection.token_metadata),
     };
 }
 
@@ -213,7 +215,7 @@ export function mapTokenContractsResponse(
     response: RetrieveTokenContractsResponse
 ): ToriiTokenContracts {
     return {
-        items: response.tokens.map(mapTokenContract),
+        items: response.token_contracts.map(mapTokenContract),
         next_cursor: response.next_cursor || undefined,
     };
 }

--- a/packages/grpc/src/torii-client.ts
+++ b/packages/grpc/src/torii-client.ts
@@ -17,6 +17,7 @@ import type {
     Message,
     WasmU256,
     Pagination,
+    TokenContractQuery,
 } from "@dojoengine/torii-wasm";
 
 import type { KeysClause as GrpcKeysClause } from "./generated/types";
@@ -301,7 +302,9 @@ export class ToriiGrpcClient {
         return this.mappers.tokenBalancesResponse(response);
     }
 
-    async getTokenContracts(query: TokenBalanceQuery): Promise<TokenContracts> {
+    async getTokenContracts(
+        query: TokenContractQuery
+    ): Promise<TokenContracts> {
         const request = createRetrieveTokenContractsRequest(query);
         const response =
             await this.client.worldClient.retrieveTokenContracts(request)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [ ] Performed self-review of the code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Subscribe to live token transfer events and update existing subscriptions.
  - Retrieve historical token transfers with filtering by accounts, contracts, and token IDs.
  - Enhanced token contract data: contract type, total supply, traits, and token metadata.
  - Richer token queries: filter by token IDs and metadata attributes.

- Refactor
  - Token contracts retrieval now uses TokenContractQuery; response field renamed to token_contracts.
  - Client method getTokenContracts updated to accept TokenContractQuery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->