### PR TITLE
fix(state): resolve biome lint errors

### DIFF
--- a/packages/state/src/__tests__/recs-implementation.test.ts
+++ b/packages/state/src/__tests__/recs-implementation.test.ts
@@ -5,6 +5,30 @@ import { createBatchTestData, testData } from "./test-utils";
 // These tests are disabled until we can properly mock modules
 // or rewrite them as integration tests
 
+// Declare mock stubs so the skipped test suite compiles without
+// "noUndeclaredVariables" lint errors.  These would normally be
+// created by a module-mocking system (e.g. vi.mock / jest.mock).
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const noop = () => {};
+const mockSetComponent: any = {
+    mockClear: noop,
+    mock: { calls: [] as any[] },
+    not: { toHaveBeenCalled: noop },
+};
+const mockGetComponentValue: any = { mockClear: noop, mockReturnValue: noop };
+const mockHasComponent: any = { mockClear: noop, mockReturnValue: noop };
+const mockRemoveComponent: any = {
+    mockClear: noop,
+    not: { toHaveBeenCalled: noop },
+};
+const mockUpdateComponent: any = { mockClear: noop };
+const mockConvertValues: any = {
+    mockClear: noop,
+    mockReturnValue: noop,
+    mockImplementation: noop,
+};
+const setEntities: any = async () => {};
+
 describe.skip("RECS State Implementation (mock-based tests)", () => {
     let mockComponents;
 


### PR DESCRIPTION
Fixes all 45 pre-existing biome lint errors in `@dojoengine/state`.

All errors were `noUndeclaredVariables` in the skipped RECS test suite. Added stub declarations for 7 mock variables that would normally be created by a module-mocking system.

No behavioral changes — the test suite remains `describe.skip`.

- `bun run lint` ✅
- `bun run format` ✅
- `bun run build:packages` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure with additional mock declarations to support compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->