### PR TITLE
feat(sdk): make initial fetch optional on subscriptions

### DIFF
--- a/.changeset/optional-initial-fetch.md
+++ b/.changeset/optional-initial-fetch.md
@@ -1,0 +1,6 @@
+---
+"@dojoengine/sdk": minor
+"@dojoengine/internal": minor
+---
+
+Add `fetchInitialData` option to `subscribeEntityQuery` and `subscribeEventQuery`. When set to `false`, the initial fetch is skipped and only the subscription is opened. Defaults to `true` for backward compatibility.

--- a/packages/internal/src/types.ts
+++ b/packages/internal/src/types.ts
@@ -951,6 +951,13 @@ export interface SubscribeParams<T extends SchemaType> {
     callback: SubscriptionCallback<StandardizedQueryResult<T>>;
 
     /**
+     * Whether to fetch initial data when subscribing.
+     * Defaults to `true` for backward compatibility.
+     * Set to `false` to skip the initial fetch and only open the subscription.
+     */
+    fetchInitialData?: boolean;
+
+    /**
      * @deprecated - Use `query.historical()` instead
      */
     historical?: boolean;

--- a/packages/sdk/src/createSDK.ts
+++ b/packages/sdk/src/createSDK.ts
@@ -251,16 +251,31 @@ export function createSDK<T extends SchemaType>({
          * @param {SubscribeParams<T>} params - Parameters object
          * @returns {Promise<SubscribeResponse<T>>} - A promise that resolves when the subscription is set up.
          */
-        subscribeEntityQuery: async ({ query, callback }) => {
+        subscribeEntityQuery: async ({
+            query,
+            callback,
+            fetchInitialData = true,
+        }) => {
             const q = query.build();
 
-            const entities = await sdkClient.getEntities(q);
+            if (fetchInitialData) {
+                const entities = await sdkClient.getEntities(q);
+                const parsedEntities = parseEntities<T>(entities.items);
+                return [
+                    Pagination.fromQuery(
+                        query,
+                        entities.next_cursor
+                    ).withItems(parsedEntities),
+                    await grpcClientInstance.onEntityUpdated(
+                        q.clause,
+                        q.world_addresses,
+                        subscribeQueryModelCallback(callback)
+                    ),
+                ];
+            }
 
-            const parsedEntities = parseEntities<T>(entities.items);
             return [
-                Pagination.fromQuery(query, entities.next_cursor).withItems(
-                    parsedEntities
-                ),
+                Pagination.fromQuery(query, undefined).withItems([]),
                 await grpcClientInstance.onEntityUpdated(
                     q.clause,
                     q.world_addresses,
@@ -278,15 +293,29 @@ export function createSDK<T extends SchemaType>({
         subscribeEventQuery: async ({
             query,
             callback,
+            fetchInitialData = true,
         }: SubscribeParams<T>): Promise<SubscribeResponse<T>> => {
             const q = query.build();
 
-            const entities = await grpcClientInstance.getEventMessages(q);
-            const parsedEntities = parseEntities<T>(entities.items);
+            if (fetchInitialData) {
+                const entities =
+                    await grpcClientInstance.getEventMessages(q);
+                const parsedEntities = parseEntities<T>(entities.items);
+                return [
+                    Pagination.fromQuery(
+                        query,
+                        entities.next_cursor
+                    ).withItems(parsedEntities),
+                    await grpcClientInstance.onEventMessageUpdated(
+                        q.clause,
+                        q.world_addresses,
+                        subscribeQueryModelCallback(callback)
+                    ),
+                ];
+            }
+
             return [
-                Pagination.fromQuery(query, entities.next_cursor).withItems(
-                    parsedEntities
-                ),
+                Pagination.fromQuery(query, undefined).withItems([]),
                 await grpcClientInstance.onEventMessageUpdated(
                     q.clause,
                     q.world_addresses,

--- a/packages/sdk/src/createSDK.ts
+++ b/packages/sdk/src/createSDK.ts
@@ -262,10 +262,9 @@ export function createSDK<T extends SchemaType>({
                 const entities = await sdkClient.getEntities(q);
                 const parsedEntities = parseEntities<T>(entities.items);
                 return [
-                    Pagination.fromQuery(
-                        query,
-                        entities.next_cursor
-                    ).withItems(parsedEntities),
+                    Pagination.fromQuery(query, entities.next_cursor).withItems(
+                        parsedEntities
+                    ),
                     await grpcClientInstance.onEntityUpdated(
                         q.clause,
                         q.world_addresses,
@@ -298,14 +297,12 @@ export function createSDK<T extends SchemaType>({
             const q = query.build();
 
             if (fetchInitialData) {
-                const entities =
-                    await grpcClientInstance.getEventMessages(q);
+                const entities = await grpcClientInstance.getEventMessages(q);
                 const parsedEntities = parseEntities<T>(entities.items);
                 return [
-                    Pagination.fromQuery(
-                        query,
-                        entities.next_cursor
-                    ).withItems(parsedEntities),
+                    Pagination.fromQuery(query, entities.next_cursor).withItems(
+                        parsedEntities
+                    ),
                     await grpcClientInstance.onEventMessageUpdated(
                         q.clause,
                         q.world_addresses,


### PR DESCRIPTION
## Summary

Adds a `fetchInitialData` option to `subscribeEntityQuery()` and `subscribeEventQuery()`. When set to `false`, the initial `getEntities`/`getEventMessages` call is skipped and only the gRPC subscription is opened.

Closes #461

## Changes

- Added `fetchInitialData?: boolean` to `SubscribeParams<T>` interface (defaults to `true`)
- Updated `subscribeEntityQuery` to conditionally skip initial `getEntities` fetch
- Updated `subscribeEventQuery` to conditionally skip initial `getEventMessages` fetch
- Added test for `fetchInitialData: false` behavior
- When skipped, returns empty pagination with an empty items array

## Usage

```typescript
// Default behavior (unchanged) - fetches initial data
const [data, sub] = await sdk.subscribeEntityQuery({
    query: myQuery,
    callback: onUpdate,
});

// Skip initial fetch - only subscribe to updates
const [emptyData, sub] = await sdk.subscribeEntityQuery({
    query: myQuery,
    callback: onUpdate,
    fetchInitialData: false,
});
```

## Backward Compatibility

Default is `true`, so existing code works without changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `fetchInitialData` flag to subscriptions, allowing you to skip initial data fetching and open only the subscription stream. Defaults to true for backward compatibility.

* **Tests**
  * Added test coverage for the new `fetchInitialData` flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->