### PR TITLE
fix(react): deep merge models by namespace in entity updates

### DIFF
--- a/.changeset/fix-deep-merge-models.md
+++ b/.changeset/fix-deep-merge-models.md
@@ -1,0 +1,5 @@
+---
+"@dojoengine/react": patch
+---
+
+Fix shallow merge in entity subscription updates that caused sibling models within a namespace to be lost when a single model was updated via subscription.

--- a/packages/react/src/effect/atoms/entities.ts
+++ b/packages/react/src/effect/atoms/entities.ts
@@ -386,10 +386,14 @@ function mergeModels(
     existing: Record<string, Record<string, unknown>>,
     updates: Record<string, Record<string, unknown>>
 ): Record<string, Record<string, unknown>> {
-    return {
-        ...existing,
-        ...updates,
-    };
+    const result = { ...existing };
+    for (const namespace in updates) {
+        result[namespace] = {
+            ...existing[namespace],
+            ...updates[namespace],
+        };
+    }
+    return result;
 }
 
 function applyFormatters(


### PR DESCRIPTION
## Problem

`mergeModels` in `createEntityQueryWithUpdatesAtom` and `createEntitiesInfiniteScrollWithUpdatesAtom` does a shallow spread:

```ts
{ ...existing, ...updates }
```

When a subscription update arrives for a single model (e.g. `ARCADE-Order`), the parsed update produces `{ ARCADE: { Order: {...} } }`. The shallow spread replaces the entire `ARCADE` namespace, losing sibling models like `Game`, `Book`, etc.

This means derived atoms (like `listingsAtom` in arcade) may not see updated entities because the merge destroys other model data on the same entity.

## Fix

Deep merge at the namespace level:

```ts
const result = { ...existing };
for (const namespace in updates) {
    result[namespace] = {
        ...existing[namespace],
        ...updates[namespace],
    };
}
return result;
```

Only the specific models within a namespace get replaced; siblings are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Fixed entity subscription updates that were incorrectly removing sibling entities within the same namespace when applying targeted updates. The subscription system now performs proper deep merging to preserve all related entities while correctly applying updates, preventing unintended data loss during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->