### PR TITLE
chore: bump Starknet.js to 9.4.2

### DIFF
--- a/.changeset/starknet-v9-support.md
+++ b/.changeset/starknet-v9-support.md
@@ -1,0 +1,16 @@
+---
+"@dojoengine/core": minor
+"@dojoengine/create-burner": minor
+"@dojoengine/create-dojo": minor
+"@dojoengine/grpc": minor
+"@dojoengine/internal": minor
+"@dojoengine/predeployed-connector": minor
+"@dojoengine/react": minor
+"@dojoengine/sdk": minor
+"@dojoengine/state": minor
+"@dojoengine/utils": minor
+---
+
+Bump Starknet.js support to v9.4.2.
+
+Starknet.js peer and dependency ranges now target v9. Stable `@starknet-react/core` currently still declares a `starknet` v8 peer range, so installs pin Starknet.js through package-manager overrides until upstream widens that peer range. Generated React apps also include the Starknet React peer dependency needed for clean package installs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Bun workspace monorepo with Turbo orchestration. Packages in `/packages/`:
 - **@dojoengine/create-burner** - Burner wallet hooks for local testing
 - **@dojoengine/create-dojo** - CLI scaffolding for new Dojo projects
 
-Key external deps: `starknet` (^8.1.2), `@dojoengine/torii-wasm`/`torii-client` (1.8.2), `zustand`, `effect`.
+Key external deps: `starknet` (^9.4.2), `@dojoengine/torii-wasm`/`torii-client` (1.8.2), `zustand`, `effect`.
 
 ## Code Style
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
     },
     "packages/core": {
       "name": "@dojoengine/core",
-      "version": "1.8.5",
+      "version": "1.8.8",
       "bin": {
         "compile-abi": "./dist/cli/compile-abi.js",
       },
@@ -100,7 +100,7 @@
     },
     "packages/create-burner": {
       "name": "@dojoengine/create-burner",
-      "version": "1.8.7",
+      "version": "1.8.10",
       "dependencies": {
         "@dojoengine/core": "workspace:*",
         "@scure/bip32": "^1.5.0",
@@ -135,7 +135,7 @@
     },
     "packages/create-dojo": {
       "name": "@dojoengine/create-dojo",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "bin": "./dist/index.cjs",
       "dependencies": {
         "@inquirer/prompts": "^3.3.2",
@@ -159,7 +159,7 @@
     },
     "packages/grpc": {
       "name": "@dojoengine/grpc",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "dependencies": {
         "@effect/opentelemetry": "^0.59.1",
         "@grpc/grpc-js": "^1.13.4",
@@ -188,7 +188,7 @@
     },
     "packages/internal": {
       "name": "@dojoengine/internal",
-      "version": "1.7.6",
+      "version": "1.8.0",
       "dependencies": {
         "@dojoengine/core": "workspace:*",
         "@dojoengine/torii-client": "catalog:",
@@ -208,7 +208,7 @@
     },
     "packages/predeployed-connector": {
       "name": "@dojoengine/predeployed-connector",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "dependencies": {
         "@starknet-io/types-js": "catalog:",
       },
@@ -234,7 +234,7 @@
     },
     "packages/react": {
       "name": "@dojoengine/react",
-      "version": "1.8.5",
+      "version": "1.8.11",
       "dependencies": {
         "@dojoengine/core": "workspace:*",
         "@dojoengine/grpc": "workspace:*",
@@ -281,7 +281,7 @@
     },
     "packages/sdk": {
       "name": "@dojoengine/sdk",
-      "version": "1.8.10",
+      "version": "1.9.0",
       "dependencies": {
         "@dojoengine/core": "workspace:*",
         "@dojoengine/grpc": "workspace:*",
@@ -325,7 +325,7 @@
     },
     "packages/state": {
       "name": "@dojoengine/state",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "dependencies": {
         "@dojoengine/recs": "2.0.13",
         "@dojoengine/torii-client": "catalog:",
@@ -344,7 +344,7 @@
     },
     "packages/utils": {
       "name": "@dojoengine/utils",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "dependencies": {
         "@dojoengine/recs": "2.0.13",
         "@latticexyz/utils": "^2.2.8",
@@ -364,6 +364,9 @@
       },
     },
   },
+  "overrides": {
+    "starknet": "^9.4.2",
+  },
   "catalog": {
     "@dojoengine/torii-client": "1.8.2",
     "@dojoengine/torii-wasm": "1.8.2",
@@ -375,15 +378,15 @@
     "@opentelemetry/sdk-metrics": "^2.2.0",
     "@opentelemetry/sdk-trace-base": "^2.2.0",
     "@opentelemetry/sdk-trace-node": "^2.2.0",
-    "@starknet-io/get-starknet-core": "4.0.7",
-    "@starknet-io/types-js": "^0.9.1",
-    "@starknet-react/chains": "^5.0.1",
-    "@starknet-react/core": "^5.0.1",
+    "@starknet-io/get-starknet-core": "4.0.8",
+    "@starknet-io/types-js": "^0.10.2",
+    "@starknet-react/chains": "^5.0.3",
+    "@starknet-react/core": "^5.0.3",
     "@types/react": "^18.0.0 || ^19.0.0",
     "@types/react-dom": "^18.0.0 || ^19.0.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "starknet": "^8.1.2",
+    "starknet": "^9.4.2",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.0", "", {}, "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="],
@@ -1102,13 +1105,15 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
-    "@starknet-io/get-starknet-core": ["@starknet-io/get-starknet-core@4.0.7", "", { "dependencies": { "@module-federation/runtime": "^0.1.2", "@starknet-io/types-js": "^0.7.7", "async-mutex": "^0.5.0" } }, "sha512-ocwQTdDvGa+0CvjGygyaTuFkda2R82dofydts8uXr9p0Diy/bmYW1fkuqJfi1nC5M+YcvvuEpl6wFvwXM1og5w=="],
+    "@starknet-io/get-starknet-core": ["@starknet-io/get-starknet-core@4.0.8", "", { "dependencies": { "@module-federation/runtime": "^0.1.2", "@starknet-io/types-js": "^0.7.7", "async-mutex": "^0.5.0" } }, "sha512-UCyaO5T+5IZN1qPiQhLPzCSmoy06FU42tZtDmpj0UifSP7vdSMe+KRnkegiikpPJ8wZmel1o26GQkBFoUrHQlQ=="],
 
-    "@starknet-io/starknet-types-08": ["@starknet-io/types-js@0.8.4", "", {}, "sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ=="],
+    "@starknet-io/get-starknet-wallet-standard": ["@starknet-io/get-starknet-wallet-standard@5.0.0", "", { "dependencies": { "@starknet-io/types-js": "^0.7.10", "@wallet-standard/base": "^1.1.0", "@wallet-standard/features": "^1.1.0", "ox": "^0.4.4" } }, "sha512-isDNGDlp16W24HE4IuweYXLDRZN0JbsDnazAieeKXE87Mn+jqhsjgTsMxcwWTjX7v906Bjz39FiDjGUddnr36g=="],
+
+    "@starknet-io/starknet-types-010": ["@starknet-io/types-js@0.10.0", "", {}, "sha512-7ALSydz6pq3YIOpq5a7OkkxqwJciMc9Nlph0OGjhcC3xX0xH30XgizmziLyYVN10oO9+BJk8M9KbJjpzdbtRSw=="],
 
     "@starknet-io/starknet-types-09": ["@starknet-io/types-js@0.9.2", "", {}, "sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg=="],
 
-    "@starknet-io/types-js": ["@starknet-io/types-js@0.9.2", "", {}, "sha512-vWOc0FVSn+RmabozIEWcEny1I73nDGTvOrLYJsR1x7LGA3AZmqt4i/aW69o/3i2NN5CVP8Ok6G1ayRQJKye3Wg=="],
+    "@starknet-io/types-js": ["@starknet-io/types-js@0.10.2", "", {}, "sha512-AtUFPYdmo9DqVus++aBSoY9W13/2PZmillPr8/mXZjc+V0iYJ/QTmkTsbw+es2mnLeLhYWSymW9ivQzyyyKdog=="],
 
     "@starknet-react/chains": ["@starknet-react/chains@5.0.3", "", {}, "sha512-TxP391OTWgaqujT9Hu1Siljye54IHjEXrgkUuhMfxzf9sCu5q42ZzZgu9hLm0NcJgg9Fx2t75J0WB6eYmQ26fw=="],
 
@@ -1277,6 +1282,10 @@
     "@vue/server-renderer": ["@vue/server-renderer@3.5.22", "", { "dependencies": { "@vue/compiler-ssr": "3.5.22", "@vue/shared": "3.5.22" }, "peerDependencies": { "vue": "3.5.22" } }, "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ=="],
 
     "@vue/shared": ["@vue/shared@3.5.22", "", {}, "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w=="],
+
+    "@wallet-standard/base": ["@wallet-standard/base@1.1.0", "", {}, "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ=="],
+
+    "@wallet-standard/features": ["@wallet-standard/features@1.1.0", "", { "dependencies": { "@wallet-standard/base": "^1.1.0" } }, "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg=="],
 
     "@yarnpkg/lockfile": ["@yarnpkg/lockfile@1.1.0", "", {}, "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="],
 
@@ -2274,7 +2283,7 @@
 
     "outdent": ["outdent@0.5.0", "", {}, "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q=="],
 
-    "ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
+    "ox": ["ox@0.4.4", "", { "dependencies": { "@adraffy/ens-normalize": "^1.10.1", "@noble/curves": "^1.6.0", "@noble/hashes": "^1.5.0", "@scure/bip32": "^1.5.0", "@scure/bip39": "^1.4.0", "abitype": "^1.0.6", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-oJPEeCDs9iNiPs6J0rTx+Y0KGeCGyCAA3zo94yZhm8G5WpOxrwUtn2Ie/Y8IyARSqqY/j9JTKA3Fc1xs1DvFnw=="],
 
     "p-filter": ["p-filter@2.1.0", "", { "dependencies": { "p-map": "^2.0.0" } }, "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw=="],
 
@@ -2566,7 +2575,7 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
-    "starknet": ["starknet@8.6.0", "", { "dependencies": { "@noble/curves": "~1.7.0", "@noble/hashes": "~1.6.0", "@scure/base": "~1.2.1", "@scure/starknet": "1.1.0", "@starknet-io/starknet-types-08": "npm:@starknet-io/types-js@~0.8.4", "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1", "abi-wan-kanabi": "2.2.4", "lossless-json": "^4.2.0", "pako": "^2.0.4", "ts-mixer": "^6.0.3" } }, "sha512-5rDiJPnc3GpH7KA8B/TqCzKgdpZbxaA52clf/OEhDKhMbbJpWeRcDqKKC8u+kFD9Nd/Rt6y2hwmZ32u82Ycurg=="],
+    "starknet": ["starknet@9.4.2", "", { "dependencies": { "@noble/curves": "~1.7.0", "@noble/hashes": "~1.6.0", "@scure/base": "~1.2.1", "@scure/starknet": "1.1.0", "@starknet-io/get-starknet-wallet-standard": "^5.0.0", "@starknet-io/starknet-types-010": "npm:@starknet-io/types-js@0.10.0", "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.1", "abi-wan-kanabi": "2.2.4", "lossless-json": "^4.2.0", "pako": "^2.0.4", "ts-mixer": "^6.0.3" } }, "sha512-NFtg077DjddHUSh8sLZ5uB149LEF4NR90FuJ0oF7+zhce7l0oG9Ubqr3H4+jHm/ghHtV+yjlv1UhEoo4SBfILA=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -3004,6 +3013,8 @@
 
     "@starknet-io/get-starknet-core/@starknet-io/types-js": ["@starknet-io/types-js@0.7.10", "", {}, "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w=="],
 
+    "@starknet-io/get-starknet-wallet-standard/@starknet-io/types-js": ["@starknet-io/types-js@0.7.10", "", {}, "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w=="],
+
     "@starknet-react/core/@starknet-io/types-js": ["@starknet-io/types-js@0.7.10", "", {}, "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w=="],
 
     "@sveltejs/vite-plugin-svelte/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
@@ -3174,7 +3185,7 @@
 
     "ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
-    "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+    "ox/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -3263,6 +3274,8 @@
     "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
+
+    "viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
 
     "vite/esbuild": ["esbuild@0.15.18", "", { "optionalDependencies": { "@esbuild/android-arm": "0.15.18", "@esbuild/linux-loong64": "0.15.18", "esbuild-android-64": "0.15.18", "esbuild-android-arm64": "0.15.18", "esbuild-darwin-64": "0.15.18", "esbuild-darwin-arm64": "0.15.18", "esbuild-freebsd-64": "0.15.18", "esbuild-freebsd-arm64": "0.15.18", "esbuild-linux-32": "0.15.18", "esbuild-linux-64": "0.15.18", "esbuild-linux-arm": "0.15.18", "esbuild-linux-arm64": "0.15.18", "esbuild-linux-mips64le": "0.15.18", "esbuild-linux-ppc64le": "0.15.18", "esbuild-linux-riscv64": "0.15.18", "esbuild-linux-s390x": "0.15.18", "esbuild-netbsd-64": "0.15.18", "esbuild-openbsd-64": "0.15.18", "esbuild-sunos-64": "0.15.18", "esbuild-windows-32": "0.15.18", "esbuild-windows-64": "0.15.18", "esbuild-windows-arm64": "0.15.18" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q=="],
 
@@ -3535,6 +3548,8 @@
     "tar/fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "typedoc/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "viem/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
     "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
             "example"
         ],
         "catalog": {
-            "starknet": "^8.1.2",
+            "starknet": "^9.4.2",
             "@dojoengine/torii-wasm": "1.8.2",
             "@dojoengine/torii-client": "1.8.2",
-            "@starknet-io/get-starknet-core": "4.0.7",
-            "@starknet-react/core": "^5.0.1",
-            "@starknet-react/chains": "^5.0.1",
-            "@starknet-io/types-js": "^0.9.1",
+            "@starknet-io/get-starknet-core": "4.0.8",
+            "@starknet-react/core": "^5.0.3",
+            "@starknet-react/chains": "^5.0.3",
+            "@starknet-io/types-js": "^0.10.2",
             "@types/react": "^18.0.0 || ^19.0.0",
             "@types/react-dom": "^18.0.0 || ^19.0.0",
             "react": "^18.0.0 || ^19.0.0",
@@ -28,6 +28,9 @@
             "@opentelemetry/sdk-logs": "^0.208.0",
             "@opentelemetry/sdk-metrics": "^2.2.0"
         }
+    },
+    "overrides": {
+        "starknet": "^9.4.2"
     },
     "scripts": {
         "postinstall": "bun run warmup:wasm",

--- a/packages/create-dojo/src/generators/client-app.ts
+++ b/packages/create-dojo/src/generators/client-app.ts
@@ -41,11 +41,20 @@ async function createPackageJson(config: ProjectConfig) {
         private: true,
         type: "module",
         scripts: {},
+        overrides: {
+            starknet: "^9.4.2",
+        },
+        pnpm: {
+            overrides: {
+                starknet: "^9.4.2",
+            },
+        },
         dependencies: {
             "@dojoengine/core": versions.core,
             "@dojoengine/sdk": versions.sdk,
             "@dojoengine/torii-wasm": versions.toriiWasm,
             "@dojoengine/predeployed-connector": versions.predeployedConnector,
+            starknet: "^9.4.2",
         },
         devDependencies: {
             typescript: "^5.6.2",
@@ -61,8 +70,9 @@ async function createPackageJson(config: ProjectConfig) {
                 "react-dom": "^18.3.1",
                 "@tanstack/react-query": "^5.0.0",
                 viem: "^2.21.54",
-                "@starknet-react/chains": "^3.0.0",
-                "@starknet-react/core": "^3.0.0",
+                "@starknet-react/chains": "^5.0.3",
+                "@starknet-react/core": "^5.0.3",
+                "get-starknet-core": "^4.0.0",
             };
             packageJson.devDependencies = {
                 ...packageJson.devDependencies,


### PR DESCRIPTION
Closes #

## Introduced changes

- Bumps the workspace Starknet.js catalog to `^9.4.2`, refreshes adjacent Starknet packages, and updates `bun.lock`.
- Pins `starknet` through package-manager overrides because stable `@starknet-react/core` still advertises a v8 peer range.
- Updates create-dojo generated React app dependencies, dependency docs, and adds a minor Changeset.

## Checklist

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Add a dedicated CI job for new examples
- [x] Performed self-review of the code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this is a major-version upgrade of `starknet` and related wallet/type packages, which can introduce runtime/API incompatibilities across all consumers. Added package-manager overrides to force-install v9 may mask upstream peer-range conflicts until dependencies (notably `@starknet-react/core`) update.
> 
> **Overview**
> Updates the monorepo to target **Starknet.js v9.4.2** by bumping the workspace `starknet` catalog/ranges and refreshing adjacent Starknet ecosystem deps (`@starknet-react/*`, `@starknet-io/*`), with the corresponding `bun.lock` churn.
> 
> Adds **package-manager `overrides`** (root and in `create-dojo` generated apps, including `pnpm.overrides`) to pin `starknet` to v9 despite `@starknet-react/core` still declaring a v8 peer range, and updates the React app generator to include the needed Starknet React peer deps (e.g. `get-starknet-core`).
> 
> Introduces a changeset marking multiple `@dojoengine/*` packages for **minor releases** and updates dependency documentation to reflect the new Starknet.js baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197ba4e8886cb9d3bddf445006a87282de14c5c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Starknet.js to v9.4.2 (previously v8.1.2)
  * Updated Starknet React packages to v5.0.3
  * Updated related Starknet ecosystem package versions
  * Generated client applications now include latest dependency versions

* **Documentation**
  * Updated external dependency version references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->