### PR TITLE
chore: add docs-sync workflow to open PRs against dojoengine/book

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,31 @@
+name: docs-sync
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "Commit SHA to analyze for documentation updates"
+        required: true
+        type: string
+
+jobs:
+  docs-sync:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    uses: dojoengine/book/.github/workflows/docs-sync.yml@main
+    with:
+      target-docs-repo: dojoengine/book
+      source-repo-slug: dojoengine/dojo.js
+      diff-globs: |
+        *.ts
+        *.tsx
+        *.md
+      docs-patterns: |
+        ^packages/.*/src/.*\.(ts|tsx)$
+      canonical-desc: |
+        The JavaScript/TypeScript SDK is documented on a SINGLE PAGE: docs-repo/docs/pages/client/sdk/javascript.md. Do NOT create new pages or subdirectories under client/sdk/.
+      docs-structure-desc: |
+        The site uses Vocs. Content lives in `docs-repo/docs/pages/`. Navigation is in `docs-repo/routes.ts`. SDK docs at `docs-repo/docs/pages/client/sdk/` are single `.md` files (bevy.md, javascript.md, unity.md, unrealengine.md, godot.md, rust.md, telegram.md), not subdirectories — the sole exception is `c/` which is a subdir.
+    secrets: inherit


### PR DESCRIPTION
Adds a caller stub that invokes the shared reusable docs-sync workflow hosted in `dojoengine/book`.

## What it does

On each merged PR to `main` (plus manual `workflow_dispatch`), the stub calls `dojoengine/book/.github/workflows/docs-sync.yml@main` with this repo's parameters (diff globs, `DOCS_PATTERNS`, canonical docs page). The shared workflow diffs the PR, runs `anthropics/claude-code-action@beta` with a tight "default to no changes / single canonical location / minimal edits" ruleset, and — if Claude made edits — opens an **auto-merging** PR to `dojoengine/book` with the suggested changes.

## Per-repo parameters

See the `with:` block in the diff. Canonical docs location for this repo:

dojo.js: single-page `docs/pages/client/sdk/javascript.md` in `dojoengine/book`.

## Requires these secrets (forwarded via `secrets: inherit`)

- `CREATE_PR_TOKEN` — PAT with `contents: write` on `dojoengine/book`.
- `ANTHROPIC_API_KEY` — for `anthropics/claude-code-action@beta`.

## Merge order

**Merge `dojoengine/book#504` first** — that's what adds the reusable workflow this stub references. Merging this stub before that one means the workflow will fail at invocation time (the `uses:` ref won't resolve).

## Related

Companion stub PRs across the dojoengine ecosystem, all pointing at the same reusable workflow:

- dojoengine/dojo#3405
- dojoengine/katana#552
- dojoengine/torii#427
- dojoengine/torii-core#68
- dojoengine/saya#71
- dojoengine/dojo.js#528
- dojoengine/dojo.c#165
- dojoengine/dojo.unity#117
- dojoengine/dojo.unreal#2
- dojoengine/dojo.bevy#6

Cross-org companion stub:
- cartridge-gg/controller#2572
