### PR TITLE
chore: release Starknet v10 packages as major

### DIFF
--- a/.changeset/starknet-v10-support.md
+++ b/.changeset/starknet-v10-support.md
@@ -1,14 +1,14 @@
 ---
-"@dojoengine/core": minor
-"@dojoengine/create-burner": minor
-"@dojoengine/create-dojo": minor
-"@dojoengine/grpc": minor
-"@dojoengine/internal": minor
-"@dojoengine/predeployed-connector": minor
-"@dojoengine/react": minor
-"@dojoengine/sdk": minor
-"@dojoengine/state": minor
-"@dojoengine/utils": minor
+"@dojoengine/core": major
+"@dojoengine/create-burner": major
+"@dojoengine/create-dojo": major
+"@dojoengine/grpc": major
+"@dojoengine/internal": major
+"@dojoengine/predeployed-connector": major
+"@dojoengine/react": major
+"@dojoengine/sdk": major
+"@dojoengine/state": major
+"@dojoengine/utils": major
 ---
 
 Bump Starknet.js support to v10.0.2 and migrate React integrations to


### PR DESCRIPTION
## Summary

- change the coordinated Starknet.js v10 and Starknet Start release set from minor to major
- produce `2.0.0` for all affected `@dojoengine/*` packages

This is required because the release raises Node to 22, React to 19, Starknet.js from v8 to v10, renames the React integration packages, and changes connector inheritance to wallet-standard.

## Validation

- `bun changeset status --verbose` reports all ten affected packages at `2.0.0`
- `bun run format:check`
- `git diff --check`

After approval and merge, dispatch the Publish packages workflow from `main` with `release_type=major`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Starknet.js support guidance to version 10.0.2.
  * Added a Node.js 22+ requirement for successful installation.
  * Updated React integration guidance to use Starknet Start packages and wallet-standard connectors.
  * Clarified generated app versions, including React 19 and pinned Starknet.js dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->