### PR TITLE
chore: use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,11 @@ on:
         default: false
         type: boolean
 
+permissions:
+  actions: write
+  contents: write
+  id-token: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -37,6 +42,11 @@ jobs:
           submodules: true
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - uses: oven-sh/setup-bun@v1
         with:
@@ -111,12 +121,6 @@ jobs:
             echo "use_prerelease=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: "Setup npm authentication"
-        run: |
-          npm config set registry https://registry.npmjs.org/
-          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-
       - name: Install dependencies
         run: bun install
 
@@ -176,8 +180,7 @@ jobs:
           # Changesets will only publish packages that are not ignored in config
           bun run release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Commit changes
         if: ${{ github.event.inputs.dry_run != 'true' && steps.check-changesets.outputs.has_changesets == 'true' }}
@@ -196,10 +199,6 @@ jobs:
           echo "DRY RUN: Would publish the following packages to npm:"
           # Show what changesets would publish
           bun changeset publish --dry-run
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Create and push tags
         if: ${{ github.event.inputs.dry_run != 'true' && steps.check-changesets.outputs.has_changesets == 'true' }}
         run: |


### PR DESCRIPTION
## Summary
- publish npm packages through GitHub Actions OIDC instead of a long-lived NPM_TOKEN
- run the npm CLI from Node 24 and enable provenance attestations
- preserve release commits, tags, and downstream release workflow dispatch permissions

## npm configuration required
Before running a real release, configure a GitHub Actions Trusted Publisher on each of the nine public packages with:

- Organization: dojoengine
- Repository: dojo.js
- Workflow: release.yaml
- Environment: blank

Packages: core, create-burner, create-dojo, grpc, predeployed-connector, react, sdk, state, and utils.

## Validation
- actionlint .github/workflows/release.yaml
- Prettier check
- git diff --check origin/main...HEAD

The previous token-backed release attempts failed npm authentication before any package, release commit, or tag was created.