### PR TITLE
fix: preserve provenance and package binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,9 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      - name: Pin npm for Changesets publishing
+        run: npm install --global npm@11.6.0
+
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,10 +4,15 @@
     "description": "dojo: Core package for interacting with dojo worlds. Execution client and other helpful functions",
     "author": "dojo",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/core"
+    },
     "main": "./dist/index.js",
     "type": "module",
     "bin": {
-        "compile-abi": "./dist/cli/compile-abi.js"
+        "compile-abi": "dist/cli/compile-abi.js"
     },
     "scripts": {
         "build:deps": "tsup",

--- a/packages/create-burner/package.json
+++ b/packages/create-burner/package.json
@@ -4,6 +4,11 @@
     "description": "dojo: Useful hooks and functions to create a Starknet burner wallet",
     "author": "Loaf",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/create-burner"
+    },
     "source": "src/index.ts",
     "main": "dist/index.js",
     "type": "module",

--- a/packages/create-dojo/package.json
+++ b/packages/create-dojo/package.json
@@ -7,6 +7,11 @@
     "main": "./dist/index.cjs",
     "type": "module",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/create-dojo"
+    },
     "publishConfig": {
         "access": "public"
     },
@@ -14,7 +19,9 @@
         "dist"
     ],
     "exports": "./dist/index.cjs",
-    "bin": "./dist/index.cjs",
+    "bin": {
+        "create-dojo": "dist/index.cjs"
+    },
     "scripts": {
         "lint:check": "biome lint .",
         "lint": "biome lint . --write",

--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -3,6 +3,11 @@
     "version": "1.8.7",
     "author": "Dojo Team",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/grpc"
+    },
     "description": "Dojo SDK: Build onchain and provable apps faster",
     "main": "dist/index.js",
     "type": "module",

--- a/packages/predeployed-connector/package.json
+++ b/packages/predeployed-connector/package.json
@@ -49,12 +49,13 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/dojoengine/sdk.git"
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/predeployed-connector"
     },
     "bugs": {
-        "url": "https://github.com/dojoengine/sdk/issues"
+        "url": "https://github.com/dojoengine/dojo.js/issues"
     },
-    "homepage": "https://github.com/dojoengine/sdk#readme",
+    "homepage": "https://github.com/dojoengine/dojo.js#readme",
     "keywords": [
         "dojo",
         "sdk",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,11 @@
         "docs": "typedoc"
     },
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/react"
+    },
     "peerDependencies": {
         "react": "^19.0.0",
         "starknet": "catalog:",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -95,12 +95,13 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/dojoengine/sdk.git"
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/sdk"
     },
     "bugs": {
-        "url": "https://github.com/dojoengine/sdk/issues"
+        "url": "https://github.com/dojoengine/dojo.js/issues"
     },
-    "homepage": "https://github.com/dojoengine/sdk#readme",
+    "homepage": "https://github.com/dojoengine/dojo.js#readme",
     "keywords": [
         "dojo",
         "sdk",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -4,6 +4,11 @@
     "description": "dojo: State syncing for dojo games",
     "author": "dojo",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/state"
+    },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,11 @@
     "description": "dojo: utils ",
     "author": "dojo",
     "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dojoengine/dojo.js.git",
+        "directory": "packages/utils"
+    },
     "main": "dist/index.js",
     "type": "module",
     "scripts": {


### PR DESCRIPTION
## Summary
- add canonical dojoengine/dojo.js repository metadata and package directories to all nine public package manifests
- correct stale sdk repository, issues, and homepage links
- pin npm 11.6.0 for the release job because npm 11.16 strips bin mappings when Changesets publishes absolute package paths
- normalize the core and create-dojo CLI mappings

## Why
OIDC authentication succeeded in release run 29135655769, but npm rejected every package with E422 because provenance expected https://github.com/dojoengine/dojo.js while package manifests were empty or pointed to dojoengine/sdk.

The same run exposed an npm 11.16 regression that would remove create-dojo and compile-abi from the published package manifests. npm 11.6.0 supports Trusted Publishing and preserves both mappings under the exact Changesets-style absolute publish invocation.

No 2.0.0 package was published, and the failed workflow created no release commit or tags.

## Validation
- release-prepared and packed all nine public packages
- verified canonical repository metadata in every packed manifest
- verified both CLI files, executable modes, and bin mappings
- exact absolute-path npm publish dry run under npm 11.6.0 without correction/removal warnings
- bun run build:packages
- bun run test
- bun run format:check
- bun run lint:check
- actionlint .github/workflows/release.yaml
- git diff --check origin/main...HEAD